### PR TITLE
don't generate IDL files and remove unused code

### DIFF
--- a/rosidl_typesupport_fastrtps_c/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_c/CMakeLists.txt
@@ -37,7 +37,6 @@ find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
-ament_export_dependencies(rosidl_generator_dds_idl)
 ament_export_dependencies(rosidl_typesupport_fastrtps_cpp)
 ament_export_include_directories(include)
 

--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -17,19 +17,6 @@ find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
 find_package(FastRTPS REQUIRED MODULE)
 
-set(_dds_idl_files "")
-set(_dds_idl_base_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_dds_idl")
-foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
-  get_filename_component(_extension "${_idl_file}" EXT)
-  if(_extension STREQUAL ".msg")
-    get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
-    get_filename_component(_parent_folder "${_parent_folder}" NAME)
-    get_filename_component(_name "${_idl_file}" NAME_WE)
-    list(APPEND _dds_idl_files
-      "${_dds_idl_base_path}/${PROJECT_NAME}/${_parent_folder}/dds_fastrtps/${_name}_.idl")
-  endif()
-endforeach()
-
 set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c/${PROJECT_NAME}")
 set(_generated_msg_files "")
 set(_generated_srv_files "")
@@ -84,12 +71,6 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   foreach(_idl_file ${${_pkg_name}_INTERFACE_FILES})
     get_filename_component(_extension "${_idl_file}" EXT)
     if(_extension STREQUAL ".msg")
-      get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
-      get_filename_component(_parent_folder "${_parent_folder}" NAME)
-      get_filename_component(_name "${_idl_file}" NAME_WE)
-      set(_abs_idl_file "${${_pkg_name}_DIR}/../${_parent_folder}/dds_fastrtps/${_name}_.idl")
-      normalize_path(_abs_idl_file "${_abs_idl_file}")
-      list(APPEND _dependency_files "${_abs_idl_file}")
       set(_abs_idl_file "${${_pkg_name}_DIR}/../${_idl_file}")
       normalize_path(_abs_idl_file "${_abs_idl_file}")
       list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
@@ -118,14 +99,13 @@ rosidl_write_generator_arguments(
   OUTPUT_DIR "${_output_path}"
   TEMPLATE_DIR "${rosidl_typesupport_fastrtps_c_TEMPLATE_DIR}"
   TARGET_DEPENDENCIES ${target_dependencies}
-  ADDITIONAL_FILES ${_dds_idl_files}
 )
 
 add_custom_command(
   OUTPUT ${_generated_msg_files} ${_generated_srv_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_fastrtps_c_BIN}
   --generator-arguments-file "${generator_arguments_file}"
-  DEPENDS ${target_dependencies} ${_dds_idl_files}
+  DEPENDS ${target_dependencies}
   COMMENT "Generating C type support for eProsima Fast-RTPS"
   VERBATIM
 )
@@ -225,10 +205,6 @@ add_dependencies(
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__cpp
-)
-add_dependencies(
-  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  ${rosidl_generate_interfaces_TARGET}__dds_fastrtps_idl
 )
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)

--- a/rosidl_typesupport_fastrtps_c/package.xml
+++ b/rosidl_typesupport_fastrtps_c/package.xml
@@ -22,7 +22,6 @@
   <buildtool_export_depend>fastrtps</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_generator_dds_idl</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_fastrtps_cpp</buildtool_export_depend>
 
   <build_export_depend>rmw</build_export_depend>

--- a/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
@@ -33,7 +33,6 @@ ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)
-ament_export_dependencies(rosidl_generator_dds_idl)
 ament_export_dependencies(rosidl_typesupport_interface)
 
 ament_export_include_directories(include)

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -26,26 +26,6 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
   endif()
 endforeach()
 
-rosidl_generate_dds_interfaces(
-  ${rosidl_generate_interfaces_TARGET}__dds_fastrtps_idl
-  IDL_FILES ${_ros_idl_files}
-  DEPENDENCY_PACKAGE_NAMES ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES}
-  OUTPUT_SUBFOLDERS "dds_fastrtps"
-)
-
-set(_dds_idl_files "")
-set(_dds_idl_base_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_dds_idl")
-foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
-  get_filename_component(_extension "${_idl_file}" EXT)
-  if(_extension STREQUAL ".msg")
-    get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
-    get_filename_component(_parent_folder "${_parent_folder}" NAME)
-    get_filename_component(_name "${_idl_file}" NAME_WE)
-    list(APPEND _dds_idl_files
-      "${_dds_idl_base_path}/${PROJECT_NAME}/${_parent_folder}/dds_fastrtps/${_name}_.idl")
-  endif()
-endforeach()
-
 set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp/${PROJECT_NAME}")
 set(_generated_msg_files "")
 set(_generated_srv_files "")
@@ -101,12 +81,6 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   foreach(_idl_file ${${_pkg_name}_INTERFACE_FILES})
   get_filename_component(_extension "${_idl_file}" EXT)
     if(_extension STREQUAL ".msg")
-      get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
-      get_filename_component(_parent_folder "${_parent_folder}" NAME)
-      get_filename_component(_name "${_idl_file}" NAME_WE)
-      set(_abs_idl_file "${${_pkg_name}_DIR}/../${_parent_folder}/dds_fastrtps/${_name}_.idl")
-      normalize_path(_abs_idl_file "${_abs_idl_file}")
-      list(APPEND _dependency_files "${_abs_idl_file}")
       set(_abs_idl_file "${${_pkg_name}_DIR}/../${_idl_file}")
       normalize_path(_abs_idl_file "${_abs_idl_file}")
       list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
@@ -137,7 +111,6 @@ rosidl_write_generator_arguments(
   OUTPUT_DIR "${_output_path}"
   TEMPLATE_DIR "${rosidl_typesupport_fastrtps_cpp_TEMPLATE_DIR}"
   TARGET_DEPENDENCIES ${target_dependencies}
-  ADDITIONAL_FILES ${_dds_idl_files}
 )
 
 set(_idl_pp "")
@@ -147,7 +120,7 @@ add_custom_command(
   --generator-arguments-file "${generator_arguments_file}"
   --dds-interface-base-path "${_dds_idl_base_path}"
   --idl-pp "${_idl_pp}"
-  DEPENDS ${target_dependencies} ${_dds_idl_files}
+  DEPENDS ${target_dependencies}
   COMMENT "Generating C++ type support for eProsima Fast-RTPS"
   VERBATIM
 )
@@ -230,10 +203,6 @@ add_dependencies(
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__cpp
-)
-add_dependencies(
-  ${rosidl_generate_interfaces_TARGET}__dds_fastrtps_idl
-  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)

--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -23,7 +23,6 @@
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_generator_dds_idl</buildtool_export_depend>
 
   <build_export_depend>rmw</build_export_depend>
 


### PR DESCRIPTION
This PR removes what I think is a leftover from copying an existing typesupport that rely on the generation of IDL files and invocation of third party generators.

@MiguelCompany Would you mind having a look and letting us know if this code is necessary ?


First attempt at CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5013)](http://ci.ros2.org/job/ci_linux/5013/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1824)](http://ci.ros2.org/job/ci_linux-aarch64/1824/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4170)](http://ci.ros2.org/job/ci_osx/4170/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5025)](http://ci.ros2.org/job/ci_windows/5025/)