### PR TITLE
remove more legacy code from Connext typesupport

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -44,27 +44,6 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
   endif()
 endforeach()
 
-# If not on Windows, disable some warnings with fastrtps's generated code
-if(NOT WIN32)
-  set(_fastrtps_compile_flags)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(_fastrtps_compile_flags
-      "-Wno-deprecated-register"
-      "-Wno-return-type-c-linkage"
-      "-Wno-unused-parameter"
-    )
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(_fastrtps_compile_flags
-      # no-strict-aliasing necessary only for Release builds
-      "-Wno-strict-aliasing"
-      "-Wno-unused-parameter"
-    )
-  endif()
-  if(NOT _fastrtps_compile_flags STREQUAL "")
-    string(REPLACE ";" " " _fastrtps_compile_flags "${_fastrtps_compile_flags}")
-  endif()
-endif()
-
 set(_dependency_files "")
 set(_dependencies "")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
@@ -131,10 +110,6 @@ if(rosidl_generate_interfaces_LIBRARY_NAME)
 endif()
 set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PROPERTIES CXX_STANDARD 14)
-if(fastrtps_GLIBCXX_USE_CXX11_ABI_ZERO)
-  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    PRIVATE fastrtps_GLIBCXX_USE_CXX11_ABI_ZERO)
-endif()
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "fastrtps"
   "rmw"
@@ -154,12 +129,6 @@ if(NOT WIN32)
 else()
   set(_target_compile_flags
     "/W4"  # Enable level 3 warnings
-    "/wd4100"  # Ignore unreferenced formal parameter warnings
-    "/wd4127"  # Ignore conditional expression is constant warnings
-    "/wd4275"  # Ignore "an exported class derived from a non-exported class" warnings
-    "/wd4305"  # Ignore "initializing: truncation from..." warnings
-    "/wd4458"  # Ignore class hides member variable warnings
-    "/wd4701"  # Ignore unused variable warnings
   )
 endif()
 string(REPLACE ";" " " _target_compile_flags "${_target_compile_flags}")

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -54,27 +54,6 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
   endif()
 endforeach()
 
-# If not on Windows, disable some warnings with fastrtps's generated code
-if(NOT WIN32)
-  set(_fastrtps_compile_flags)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(_fastrtps_compile_flags
-      "-Wno-deprecated-register"
-      "-Wno-return-type-c-linkage"
-      "-Wno-unused-parameter"
-    )
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(_fastrtps_compile_flags
-      # no-strict-aliasing necessary only for Release builds
-      "-Wno-strict-aliasing"
-      "-Wno-unused-parameter"
-    )
-  endif()
-  if(NOT _fastrtps_compile_flags STREQUAL "")
-    string(REPLACE ";" " " _fastrtps_compile_flags "${_fastrtps_compile_flags}")
-  endif()
-endif()
-
 set(_dependency_files "")
 set(_dependencies "")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
@@ -146,10 +125,6 @@ if(rosidl_generate_interfaces_LIBRARY_NAME)
 endif()
 set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PROPERTIES CXX_STANDARD 14)
-if(fastrtps_GLIBCXX_USE_CXX11_ABI_ZERO)
-  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    PRIVATE fastrtps_GLIBCXX_USE_CXX11_ABI_ZERO)
-endif()
 if(WIN32)
   target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PRIVATE "ROSIDL_TYPESUPPORT_FASTRTPS_CPP_BUILDING_DLL_${PROJECT_NAME}")
@@ -161,12 +136,6 @@ if(NOT WIN32)
 else()
   set(_target_compile_flags
     "/W4"
-    "/wd4100"
-    "/wd4127"
-    "/wd4275"
-    "/wd4305"
-    "/wd4458"
-    "/wd4701"
   )
 endif()
 string(REPLACE ";" " " _target_compile_flags "${_target_compile_flags}")


### PR DESCRIPTION
These flags apply to Connext generated code. As we don't generate any code for fastrtps it can be removed.

@MiguelCompany FYI

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5026)](http://ci.ros2.org/job/ci_linux/5026/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1834)](http://ci.ros2.org/job/ci_linux-aarch64/1834/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4180)](http://ci.ros2.org/job/ci_osx/4180/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5035)](http://ci.ros2.org/job/ci_windows/5035/)