### PR TITLE
avoid using undefined var

### DIFF
--- a/rosidl_typesupport_fastrtps_c/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_c/CMakeLists.txt
@@ -2,8 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typesupport_fastrtps_c)
 
-set(FASTRTPS_STATIC_DISABLE $ENV{FASTRTPS_STATIC_DISABLE}
-  CACHE BOOL "If fastrtps Static should be disabled.")
+if(DEFINED ENV{FASTRTPS_STATIC_DISABLE})
+  set(FASTRTPS_STATIC_DISABLE $ENV{FASTRTPS_STATIC_DISABLE}
+    CACHE BOOL "If Connext Static should be disabled.")
+else()
+  set(FASTRTPS_STATIC_DISABLE FALSE
+    CACHE BOOL "If Connext Static should be disabled.")
+endif()
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)

--- a/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
@@ -2,8 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typesupport_fastrtps_cpp)
 
-set(FASTRTPS_STATIC_DISABLE $ENV{FASTRTPS_STATIC_DISABLE}
-  CACHE BOOL "If fastrtps Static should be disabled.")
+if(DEFINED ENV{FASTRTPS_STATIC_DISABLE})
+  set(FASTRTPS_STATIC_DISABLE $ENV{FASTRTPS_STATIC_DISABLE}
+    CACHE BOOL "If Connext Static should be disabled.")
+else()
+  set(FASTRTPS_STATIC_DISABLE FALSE
+    CACHE BOOL "If Connext Static should be disabled.")
+endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
Similar to https://github.com/ros2/rosidl_typesupport_connext/pull/9

Linux build just to make sure it still builds [![Build Status](https://ci.ros2.org/job/ci_linux/5027/badge/icon)](https://ci.ros2.org/job/ci_linux/5027/)