### PR TITLE
add specialization of get_service_type_support_handle

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -49,6 +49,19 @@ static rosidl_service_type_support_t handle = {
 
 }  // namespace @(spec.pkg_name)
 
+namespace rosidl_typesupport_fastrtps_cpp
+{
+
+template<>
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_EXPORT_@(spec.pkg_name)
+const rosidl_service_type_support_t *
+get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>()
+{
+  return &@(spec.pkg_name)::srv::typesupport_fastrtps_cpp::handle;
+}
+
+}  // namespace rosidl_typesupport_fastrtps_cpp
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
Closes #3 
Although it is not currently used by downstream packages, this adds the function for consistency across the various type supports for future use


* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5028)](http://ci.ros2.org/job/ci_linux/5028/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1835)](http://ci.ros2.org/job/ci_linux-aarch64/1835/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4181)](http://ci.ros2.org/job/ci_osx/4181/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5036)](http://ci.ros2.org/job/ci_windows/5036/)

Connects to #3 