### PR TITLE
Enables generation of messages services in an 'action' directory

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -25,12 +25,21 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
   get_filename_component(_extension "${_idl_file}" EXT)
   get_filename_component(_msg_name "${_idl_file}" NAME_WE)
   string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
-  if(_extension STREQUAL ".msg" OR _extension STREQUAL ".srv")
-    list(APPEND _generated_files "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_c.h")
-    list(APPEND _generated_files "${_output_path}/${_parent_folder}/dds_fastrtps_c/${_header_name}__type_support_c.cpp")
+  if(_extension STREQUAL ".msg")
+    set(_allowed_parent_folders "msg" "srv" "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
+  elseif(_extension STREQUAL ".srv")
+    set(_allowed_parent_folders "srv" "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
   else()
     message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
   endif()
+  list(APPEND _generated_files "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_c.h")
+  list(APPEND _generated_files "${_output_path}/${_parent_folder}/dds_fastrtps_c/${_header_name}__type_support_c.cpp")
 endforeach()
 
 set(_dependency_files "")
@@ -138,12 +147,15 @@ ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   set(_msg_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/msg/dds_fastrtps_c")
   set(_srv_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/srv/dds_fastrtps_c")
+  set(_action_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/action/dds_fastrtps_c")
   normalize_path(_msg_include_dir "${_msg_include_dir}")
   normalize_path(_srv_include_dir "${_srv_include_dir}")
+  normalize_path(_action_include_dir "${_action_include_dir}")
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
     "${_msg_include_dir}"
     "${_srv_include_dir}"
+    "${_action_include_dir}"
   )
   ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})

--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -18,27 +18,16 @@ find_package(fastrtps REQUIRED CONFIG)
 find_package(FastRTPS REQUIRED MODULE)
 
 set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c/${PROJECT_NAME}")
-set(_generated_msg_files "")
-set(_generated_srv_files "")
+set(_generated_files "")
 foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
+  get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
+  get_filename_component(_parent_folder "${_parent_folder}" NAME)
   get_filename_component(_extension "${_idl_file}" EXT)
   get_filename_component(_msg_name "${_idl_file}" NAME_WE)
   string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
-  if(_extension STREQUAL ".msg")
-    get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
-    get_filename_component(_parent_folder "${_parent_folder}" NAME)
-    if(_parent_folder STREQUAL "msg")
-      set(_var2 "_generated_msg_files")
-    elseif(_parent_folder STREQUAL "srv")
-      set(_var2 "_generated_srv_files")
-    else()
-      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
-    endif()
-    list(APPEND ${_var2} "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_c.h")
-    list(APPEND ${_var2} "${_output_path}/${_parent_folder}/dds_fastrtps_c/${_header_name}__type_support_c.cpp")
-  elseif(_extension STREQUAL ".srv")
-    list(APPEND _generated_srv_files "${_output_path}/srv/${_header_name}__rosidl_typesupport_fastrtps_c.h")
-    list(APPEND _generated_srv_files "${_output_path}/srv/dds_fastrtps_c/${_header_name}__type_support_c.cpp")
+  if(_extension STREQUAL ".msg" OR _extension STREQUAL ".srv")
+    list(APPEND _generated_files "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_c.h")
+    list(APPEND _generated_files "${_output_path}/${_parent_folder}/dds_fastrtps_c/${_header_name}__type_support_c.cpp")
   else()
     message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
   endif()
@@ -83,7 +72,7 @@ rosidl_write_generator_arguments(
 )
 
 add_custom_command(
-  OUTPUT ${_generated_msg_files} ${_generated_srv_files}
+  OUTPUT ${_generated_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_fastrtps_c_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   DEPENDS ${target_dependencies}
@@ -105,7 +94,7 @@ set(_target_suffix "__rosidl_typesupport_fastrtps_c")
 
 link_directories(${fastrtps_LIBRARY_DIRS})
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
-  ${_generated_msg_files} ${_generated_srv_files})
+  ${_generated_files})
 if(rosidl_generate_interfaces_LIBRARY_NAME)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
@@ -183,7 +172,7 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     PATTERN "*.cpp" EXCLUDE
   )
 
-  if(NOT _generated_msg_files STREQUAL "" OR NOT _generated_srv_files STREQUAL "")
+  if(NOT _generated_files STREQUAL "")
     ament_export_include_directories(include)
   endif()
 
@@ -198,11 +187,11 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
-  if(NOT _generated_msg_files STREQUAL "" OR NOT _generated_srv_files STREQUAL "")
+  if(NOT _generated_files STREQUAL "")
     find_package(ament_cmake_cppcheck REQUIRED)
     ament_cppcheck(
       TESTNAME "cppcheck_rosidl_typesupport_fastrtps_c"
-      ${_generated_msg_files} ${_generated_srv_files})
+      ${_generated_files})
 
     find_package(ament_cmake_cpplint REQUIRED)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
@@ -211,13 +200,13 @@ if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"
-      ${_generated_msg_files} ${_generated_srv_files})
+      ${_generated_files})
 
     find_package(ament_cmake_uncrustify REQUIRED)
     ament_uncrustify(
       TESTNAME "uncrustify_rosidl_typesupport_fastrtps_c"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
-      ${_generated_msg_files} ${_generated_srv_files})
+      ${_generated_files})
   endif()
 endif()

--- a/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
@@ -11,7 +11,7 @@
 @#    Parsed specification of the .msg file
 @#  - subfolder (string)
 @#    The subfolder / subnamespace of the message
-@#    Either 'msg' or 'srv'
+@#    Could be either 'msg', 'srv' or 'action'
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -15,7 +15,7 @@
 @#    full type of the message; equivalent to spec.base_type.type
 @#  - subfolder (string)
 @#    The subfolder / subnamespace of the message
-@#    Either 'msg' or 'srv'
+@#    Could be either 'msg', 'srv' or 'action'
 @#  - get_header_filename_from_msg_name (function)
 @##########################################################################
 @

--- a/rosidl_typesupport_fastrtps_c/resource/srv__rosidl_typesupport_fastrtps_c.h.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__rosidl_typesupport_fastrtps_c.h.em
@@ -9,12 +9,15 @@
 @# Context:
 @#  - spec (rosidl_parser.MessageSpecification)
 @#    Parsed specification of the .srv file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the service
+@#    Either 'srv' or 'action'
 @#  - get_header_filename_from_srv_name (function)
 @#######################################################################
 @
 @{
 header_guard_parts = [
-    spec.pkg_name, 'srv',
+    spec.pkg_name, subfolder,
     get_header_filename_from_msg_name(spec.srv_name) + '__rosidl_typesupport_fastrtps_c_h']
 header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 }@
@@ -33,7 +36,7 @@ extern "C"
 
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(spec.pkg_name)
 const rosidl_service_type_support_t *
-  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), @(spec.srv_name))();
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name))();
 
 #ifdef __cplusplus
 }

--- a/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
@@ -7,10 +7,13 @@
 @# Context:
 @#  - spec (rosidl_parser.ServiceSpecification)
 @#    Parsed specification of the .srv file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message
+@#    Either 'srv' or 'action'
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__rosidl_typesupport_fastrtps_c.h"
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.srv_name))__rosidl_typesupport_fastrtps_c.h"
 
 // Provides the definition of the service_type_support_callbacks_t struct.
 #include <rosidl_typesupport_fastrtps_cpp/service_type_support.h>
@@ -21,11 +24,11 @@
 #include "@(spec.pkg_name)/msg/rosidl_typesupport_fastrtps_c__visibility_control.h"
 @{req_header_file_name = get_header_filename_from_msg_name(spec.srv_name + '__request')}@
 @{res_header_file_name = get_header_filename_from_msg_name(spec.srv_name + '__response')}@
-#include "@(spec.pkg_name)/srv/@(req_header_file_name).h"
-#include "@(spec.pkg_name)/srv/@(res_header_file_name).h"
+#include "@(spec.pkg_name)/@(subfolder)/@(req_header_file_name).h"
+#include "@(spec.pkg_name)/@(subfolder)/@(res_header_file_name).h"
 
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name + '_Request'))__rosidl_typesupport_fastrtps_c.h"
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name + '_Response'))__rosidl_typesupport_fastrtps_c.h"
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.srv_name + '_Request'))__rosidl_typesupport_fastrtps_c.h"
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.srv_name + '_Response'))__rosidl_typesupport_fastrtps_c.h"
 
 #if defined(__cplusplus)
 extern "C"
@@ -35,8 +38,8 @@ extern "C"
 static service_type_support_callbacks_t callbacks = {
   "@(spec.pkg_name)",
   "@(spec.srv_name)",
-  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), srv, @(spec.srv_name)_Request)(),
-  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), srv, @(spec.srv_name)_Response)(),
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Request)(),
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Response)(),
 };
 
 static rosidl_service_type_support_t handle = {

--- a/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
@@ -49,7 +49,7 @@ static rosidl_service_type_support_t handle = {
 };
 
 const rosidl_service_type_support_t *
-ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), @(spec.srv_name))() {
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name))() {
   return &handle;
 }
 

--- a/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c/__init__.py
+++ b/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c/__init__.py
@@ -59,10 +59,10 @@ def generate_typesupport_fastrtps_c(args):
 
     for idl_file in args['ros_interface_files']:
         extension = os.path.splitext(idl_file)[1]
+        subfolder = os.path.basename(os.path.dirname(idl_file))
         if extension == '.msg':
             spec = parse_message_file(pkg_name, idl_file)
             validate_field_types(spec, known_msg_types)
-            subfolder = os.path.basename(os.path.dirname(idl_file))
             for template_file, generated_filename in mapping_msgs.items():
                 generated_file = os.path.join(args['output_dir'], subfolder)
                 if generated_filename.endswith('.cpp'):
@@ -87,14 +87,14 @@ def generate_typesupport_fastrtps_c(args):
             spec = parse_service_file(pkg_name, idl_file)
             validate_field_types(spec, known_msg_types)
             for template_file, generated_filename in mapping_srvs.items():
-                generated_file = os.path.join(args['output_dir'], 'srv')
+                generated_file = os.path.join(args['output_dir'], subfolder)
                 if generated_filename.endswith('.cpp'):
                     generated_file = os.path.join(generated_file, 'dds_fastrtps_c')
                 generated_file = os.path.join(
                     generated_file, generated_filename %
                     convert_camel_case_to_lower_case_underscore(spec.srv_name))
 
-                data = {'spec': spec}
+                data = {'spec': spec, 'subfolder': subfolder}
                 data.update(functions)
                 expand_template(
                     template_file, data, generated_file,

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -34,12 +34,21 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
   get_filename_component(_parent_folder "${_parent_folder}" NAME)
   get_filename_component(_msg_name "${_idl_file}" NAME_WE)
   string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
-  if(_extension STREQUAL ".msg" OR _extension STREQUAL ".srv")
-    list(APPEND _generated_files "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_cpp.hpp")
-    list(APPEND _generated_files "${_output_path}/${_parent_folder}/dds_fastrtps/${_header_name}__type_support.cpp")
+  if(_extension STREQUAL ".msg")
+    set(_allowed_parent_folders "msg" "srv" "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
+  elseif(_extension STREQUAL ".srv")
+    set(_allowed_parent_folders "srv" "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
   else()
     message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
   endif()
+  list(APPEND _generated_files "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_cpp.hpp")
+  list(APPEND _generated_files "${_output_path}/${_parent_folder}/dds_fastrtps/${_header_name}__type_support.cpp")
 endforeach()
 
 set(_dependency_files "")
@@ -142,12 +151,15 @@ ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   set(_msg_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/msg/dds_fastrtps")
   set(_srv_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/srv/dds_fastrtps")
+  set(_action_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/action/dds_fastrtps")
   normalize_path(_msg_include_dir "${_msg_include_dir}")
   normalize_path(_srv_include_dir "${_srv_include_dir}")
+  normalize_path(_action_include_dir "${_action_include_dir}")  
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
     "${_msg_include_dir}"
     "${_srv_include_dir}"
+    "${_action_include_dir}"
   )
   ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -154,7 +154,7 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   set(_action_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/action/dds_fastrtps")
   normalize_path(_msg_include_dir "${_msg_include_dir}")
   normalize_path(_srv_include_dir "${_srv_include_dir}")
-  normalize_path(_action_include_dir "${_action_include_dir}")  
+  normalize_path(_action_include_dir "${_action_include_dir}")
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
     "${_msg_include_dir}"

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -9,7 +9,7 @@
 @#    Parsed specification of the .msg file
 @#  - subfolder (string)
 @#    The subfolder / subnamespace of the message
-@#    Either 'msg' or 'srv'
+@#    Could be 'msg', 'srv' or 'action'
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__rosidl_typesupport_fastrtps_cpp.hpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__rosidl_typesupport_fastrtps_cpp.hpp.em
@@ -38,7 +38,7 @@ extern "C"
 
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_@(spec.pkg_name)
 const rosidl_service_type_support_t *
-  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), @(spec.srv_name))();
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), @(subfolder), @(spec.srv_name))();
 
 #ifdef __cplusplus
 }

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__rosidl_typesupport_fastrtps_cpp.hpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__rosidl_typesupport_fastrtps_cpp.hpp.em
@@ -9,12 +9,15 @@
 @# Context:
 @#  - spec (rosidl_parser.MessageSpecification)
 @#    Parsed specification of the .srv file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message
+@#    Either 'srv' or 'action'
 @#  - get_header_filename_from_srv_name (function)
 @#######################################################################
 @
 @{
 header_guard_parts = [
-    spec.pkg_name, 'srv',
+    spec.pkg_name, subfolder,
     get_header_filename_from_msg_name(spec.srv_name) + '__rosidl_typesupport_fastrtps_cpp_hpp']
 header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 }@

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -7,24 +7,27 @@
 @# Context:
 @#  - spec (rosidl_parser.ServiceSpecification)
 @#    Parsed specification of the .srv file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message
+@#    Either 'srv' or 'action'
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__rosidl_typesupport_fastrtps_cpp.hpp"
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.srv_name))__rosidl_typesupport_fastrtps_cpp.hpp"
 
 #include "rmw/error_handling.h"
 #include "rosidl_typesupport_fastrtps_cpp/identifier.hpp"
 #include "rosidl_typesupport_fastrtps_cpp/service_type_support.h"
 #include "rosidl_typesupport_fastrtps_cpp/service_type_support_decl.hpp"
 
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name + '_Request'))__rosidl_typesupport_fastrtps_cpp.hpp"
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name + '_Response'))__rosidl_typesupport_fastrtps_cpp.hpp"
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.srv_name + '_Request'))__rosidl_typesupport_fastrtps_cpp.hpp"
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.srv_name + '_Response'))__rosidl_typesupport_fastrtps_cpp.hpp"
 
 namespace @(spec.pkg_name)
 {
 
-namespace srv
+namespace @(subfolder)
 {
 
 namespace typesupport_fastrtps_cpp
@@ -33,8 +36,8 @@ namespace typesupport_fastrtps_cpp
 static service_type_support_callbacks_t callbacks = {
   "@(spec.pkg_name)",
   "@(spec.srv_name)",
-  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), srv, @(spec.srv_name)_Request)(),
-  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), srv, @(spec.srv_name)_Response)(),
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Request)(),
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Response)(),
 };
 
 static rosidl_service_type_support_t handle = {
@@ -45,7 +48,7 @@ static rosidl_service_type_support_t handle = {
 
 }  // namespace typesupport_fastrtps_cpp
 
-}  // namespace srv
+}  // namespace @(subfolder)
 
 }  // namespace @(spec.pkg_name)
 
@@ -55,9 +58,9 @@ namespace rosidl_typesupport_fastrtps_cpp
 template<>
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_EXPORT_@(spec.pkg_name)
 const rosidl_service_type_support_t *
-get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>()
+get_service_type_support_handle<@(spec.pkg_name)::@(subfolder)::@(spec.srv_name)>()
 {
-  return &@(spec.pkg_name)::srv::typesupport_fastrtps_cpp::handle;
+  return &@(spec.pkg_name)::@(subfolder)::typesupport_fastrtps_cpp::handle;
 }
 
 }  // namespace rosidl_typesupport_fastrtps_cpp
@@ -69,7 +72,7 @@ extern "C"
 
 const rosidl_service_type_support_t *
 ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), @(spec.srv_name))() {
-  return &@(spec.pkg_name)::srv::typesupport_fastrtps_cpp::handle;
+  return &@(spec.pkg_name)::@(subfolder)::typesupport_fastrtps_cpp::handle;
 }
 
 #ifdef __cplusplus

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -71,7 +71,7 @@ extern "C"
 #endif
 
 const rosidl_service_type_support_t *
-ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), @(spec.srv_name))() {
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(spec.pkg_name), @(subfolder), @(spec.srv_name))() {
   return &@(spec.pkg_name)::@(subfolder)::typesupport_fastrtps_cpp::handle;
 }
 

--- a/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp/__init__.py
+++ b/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp/__init__.py
@@ -32,7 +32,7 @@ def parse_ros_interface_files(pkg_name, ros_interface_files):
             message_specs.append((idl_file, message_spec))
         elif extension == '.srv':
             service_spec = parse_service_file(pkg_name, idl_file)
-            service_specs.append(service_spec)
+            service_specs.append((idl_file, service_spec))
     return (message_specs, service_specs)
 
 
@@ -87,17 +87,18 @@ def generate_cpp(args, message_specs, service_specs, known_msg_types):
                 template_file, data, generated_file,
                 minimum_timestamp=latest_target_timestamp)
 
-    for spec in service_specs:
+    for idl_file, spec in service_specs:
         validate_field_types(spec, known_msg_types)
+        subfolder = os.path.basename(os.path.dirname(idl_file))
         for template_file, generated_filename in mapping_srvs.items():
-            generated_file = os.path.join(args['output_dir'], 'srv')
+            generated_file = os.path.join(args['output_dir'], subfolder)
             if generated_filename.endswith('.cpp'):
                 generated_file = os.path.join(generated_file, 'dds_fastrtps')
             generated_file = os.path.join(
                 generated_file, generated_filename %
                 convert_camel_case_to_lower_case_underscore(spec.srv_name))
 
-            data = {'spec': spec}
+            data = {'spec': spec, 'subfolder': subfolder}
             data.update(functions)
             expand_template(
                 template_file, data, generated_file,


### PR DESCRIPTION
Closes #9 
This PR enables us to generate message services from a different directory than `srv`.
Depends on some PRs that are yet pending to be sent against `rosidl`, `rosidl_typesupport` and `rosidl_dds`.

connects to ros2/rosidl#301
