### PR TITLE
Add message namespace to type support struct

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -572,8 +572,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bo
 @# // Collect the callback functions and provide a function to get the type support struct.
 
 static message_type_support_callbacks_t __callbacks_@(message.structure.namespaced_type.name) = {
-  "@(package_name)",
-  "@('::'.join(list(interface_path.parents[0].parts)))",
+  "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -573,6 +573,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bo
 
 static message_type_support_callbacks_t __callbacks_@(message.structure.namespaced_type.name) = {
   "@(package_name)",
+  "@('::'.join(list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,

--- a/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
@@ -45,7 +45,7 @@ extern "C"
 #endif
 
 static service_type_support_callbacks_t @(service.namespaced_type.name)__callbacks = {
-  "@(package_name)",
+  "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(service.namespaced_type.name)",
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))_Request)(),
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))_Response)(),

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -22,6 +22,7 @@
 typedef struct message_type_support_callbacks_t
 {
   const char * package_name_;
+  const char * message_namespace_;
   const char * message_name_;
 
   // Function for message serialization

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -21,7 +21,6 @@
 
 typedef struct message_type_support_callbacks_t
 {
-  const char * package_name_;
   const char * message_namespace_;
   const char * message_name_;
 

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
@@ -23,7 +23,7 @@
 
 typedef struct service_type_support_callbacks_t
 {
-  const char * package_name_;
+  const char * service_namespace_;
   const char * service_name_;
 
   const rosidl_message_type_support_t * request_members_;

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -445,8 +445,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bo
 }
 
 static message_type_support_callbacks_t _@(message.structure.namespaced_type.name)__callbacks = {
-  "@(package_name)",
-  "@('::'.join(list(interface_path.parents[0].parts)))",
+  "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -446,6 +446,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bo
 
 static message_type_support_callbacks_t _@(message.structure.namespaced_type.name)__callbacks = {
   "@(package_name)",
+  "@('::'.join(list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -47,7 +47,7 @@ namespace typesupport_fastrtps_cpp
 {
 
 static service_type_support_callbacks_t _@(service.namespaced_type.name)__callbacks = {
-  "@(package_name)",
+  "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(service.namespaced_type.name)",
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name)_Request)(),
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name)_Response)(),


### PR DESCRIPTION
The message namespace is to be used by rmw implementations in order to support ROS messages with arbitrary namespaces.

Connects to ros2/ros2#677