### PR TITLE
use ament_cmake_ros

### DIFF
--- a/rosidl_typesupport_fastrtps_c/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_c/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 find_package(fastrtps_cmake_module REQUIRED)
 find_package(fastcdr REQUIRED CONFIG)
@@ -48,7 +48,7 @@ ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
   src/identifier.cpp
   src/wstring_conversion.cpp)
 if(WIN32)

--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+find_package(ament_cmake_ros REQUIRED)
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
@@ -90,7 +91,7 @@ configure_file(
 set(_target_suffix "__rosidl_typesupport_fastrtps_c")
 
 link_directories(${fastrtps_LIBRARY_DIRS})
-add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
+add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${_generated_files})
 if(rosidl_generate_interfaces_LIBRARY_NAME)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_fastrtps_c/package.xml
+++ b/rosidl_typesupport_fastrtps_c/package.xml
@@ -8,7 +8,7 @@
   <license>Apache License 2.0</license>
   <author>Ricardo González</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>fastrtps_cmake_module</buildtool_depend>
   <buildtool_depend>fastcdr</buildtool_depend>
   <buildtool_depend>fastrtps</buildtool_depend>
@@ -16,7 +16,7 @@
   <buildtool_depend>rosidl_runtime_c</buildtool_depend>
   <buildtool_depend>rosidl_typesupport_fastrtps_cpp</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>fastrtps_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>fastcdr</buildtool_export_depend>
   <buildtool_export_depend>fastrtps</buildtool_export_depend>

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+find_package(ament_cmake_ros REQUIRED)
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
@@ -101,7 +102,7 @@ configure_file(
 set(_target_suffix "__rosidl_typesupport_fastrtps_cpp")
 
 # Create a library that builds the generated files
-add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
+add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${_generated_files})
 
 # Change output library name if asked to

--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -16,7 +16,7 @@
   <buildtool_depend>rosidl_runtime_c</buildtool_depend>
   <buildtool_depend>rosidl_runtime_cpp</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>fastrtps_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>fastcdr</buildtool_export_depend>
   <buildtool_export_depend>fastrtps</buildtool_export_depend>


### PR DESCRIPTION
Allowing to choose between shared and static libraries.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9335)](http://ci.ros2.org/job/ci_linux/9335/) (same test also failing on master: https://ci.ros2.org/job/ci_linux/9336/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5022)](http://ci.ros2.org/job/ci_linux-aarch64/5022/) (same as Linux)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7642)](http://ci.ros2.org/job/ci_osx/7642/) (it seems the same tests are failing in the nightly - hard to tell with that number though)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9255)](http://ci.ros2.org/job/ci_windows/9255/) (PyQt failures unrelated to this change)
* Windows-container [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=127)](http://ci.ros2.org/job/ci_windows-container/127/)