### PR TITLE
Move headers under detail subfolder and use modern cmake to fix single typesupport builds

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -26,8 +26,8 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
   get_filename_component(_idl_name "${_abs_idl_file}" NAME_WE)
   string_camel_case_to_lower_case_underscore("${_idl_name}" _header_name)
   list(APPEND _generated_files
-    "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_c.h"
-    "${_output_path}/${_parent_folder}/${_header_name}__type_support_c.cpp")
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__rosidl_typesupport_fastrtps_c.h"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__type_support_c.cpp")
 endforeach()
 
 set(_dependency_files "")

--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NOT rosidl_generator_c_FOUND)
+  message(FATAL_ERROR
+    "'rosidl_generator_c' not found when executing "
+    "'rosidl_typesupport_fastrtps_c' extension.")
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
@@ -123,15 +129,10 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PROPERTIES COMPILE_FLAGS "${_target_compile_flags}")
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp
-)
-ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  "fastrtps"
-  "rosidl_typesupport_fastrtps_cpp"
-  "rosidl_typesupport_fastrtps_c"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp>"
 )
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   set(_msg_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/msg/dds_fastrtps_c")
@@ -142,14 +143,14 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   normalize_path(_action_include_dir "${_action_include_dir}")
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
-    "${_msg_include_dir}"
-    "${_srv_include_dir}"
-    "${_action_include_dir}"
+    "$<BUILD_INTERFACE:${_msg_include_dir}>"
+    "$<BUILD_INTERFACE:${_srv_include_dir}>"
+    "$<BUILD_INTERFACE:${_action_include_dir}>"
   )
   ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    ${${_pkg_name}_LIBRARIES${_target_suffix}})
+    ${${_pkg_name}_TARGETS${_target_suffix}})
 endforeach()
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
@@ -181,13 +182,14 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
 
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
-
-  rosidl_export_typesupport_libraries(${_target_suffix}
+  rosidl_export_typesupport_targets(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_typesupport_fastrtps_c/resource/idl__rosidl_typesupport_fastrtps_c.h.em
+++ b/rosidl_typesupport_fastrtps_c/resource/idl__rosidl_typesupport_fastrtps_c.h.em
@@ -13,8 +13,8 @@
 @
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_'
 }@

--- a/rosidl_typesupport_fastrtps_c/resource/idl__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/idl__type_support_c.cpp.em
@@ -13,8 +13,8 @@
 @
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 }@
 #include "@(include_base)__rosidl_typesupport_fastrtps_c.h"

--- a/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c-extras.cmake.in
+++ b/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c-extras.cmake.in
@@ -11,6 +11,10 @@ if(NOT FastRTPS_FOUND)
     "Could not find eProsima Fast-RTPS: skipping rosidl_typesupport_fastrtps_c"
   )
 else()
+  # Make sure extension points are registered in order
+  find_package(rosidl_generator_c QUIET)
+  find_package(rosidl_typesupport_fastrtps_cpp QUIET REQUIRED)
+
   find_package(ament_cmake_core QUIET REQUIRED)
   ament_register_extension(
     "rosidl_generate_idl_interfaces"

--- a/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c/__init__.py
+++ b/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c/__init__.py
@@ -18,7 +18,7 @@ from rosidl_cmake import generate_files
 def generate_typesupport_fastrtps_c(generator_arguments_file):
     mapping = {
         'idl__rosidl_typesupport_fastrtps_c.h.em':
-        '%s__rosidl_typesupport_fastrtps_c.h',
-        'idl__type_support_c.cpp.em': '%s__type_support_c.cpp',
+        'detail/%s__rosidl_typesupport_fastrtps_c.h',
+        'idl__type_support_c.cpp.em': 'detail/%s__type_support_c.cpp',
     }
     generate_files(generator_arguments_file, mapping)

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -30,8 +30,8 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
   # Turn idl name into file names
   string_camel_case_to_lower_case_underscore("${_idl_name}" _header_name)
   list(APPEND _generated_files
-    "${_output_path}/${_parent_folder}/dds_fastrtps/${_header_name}__type_support.cpp"
-    "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_fastrtps_cpp.hpp"
+    "${_output_path}/${_parent_folder}/detail/dds_fastrtps/${_header_name}__type_support.cpp"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__rosidl_typesupport_fastrtps_cpp.hpp"
   )
 endforeach()
 

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NOT rosidl_generator_cpp_FOUND)
+  message(FATAL_ERROR
+    "'rosidl_generator_cpp' not found when executing "
+    "'rosidl_typesupport_fastrtps_cpp' extension.")
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
@@ -136,8 +142,8 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 # Include headers from other generators
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp>"
 )
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
@@ -152,7 +158,7 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    ${${_pkg_name}_LIBRARIES${_target_suffix}})
+    ${${_pkg_name}_TARGETS${_target_suffix}})
 endforeach()
 
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
@@ -184,13 +190,14 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
 
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
-
-  rosidl_export_typesupport_libraries(${_target_suffix}
+  rosidl_export_typesupport_targets(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_typesupport_fastrtps_cpp/resource/idl__rosidl_typesupport_fastrtps_cpp.hpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/idl__rosidl_typesupport_fastrtps_cpp.hpp.em
@@ -13,8 +13,8 @@
 @
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_'
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/idl__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/idl__type_support.cpp.em
@@ -13,15 +13,12 @@
 @
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
-include_base = '/'.join(include_parts)
-include_parts_detail = [package_name] + list(interface_path.parents[0].parts) + [
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
-include_base_detail = '/'.join(include_parts_detail)
+include_base = '/'.join(include_parts)
 }@
 #include "@(include_base)__rosidl_typesupport_fastrtps_cpp.hpp"
-#include "@(include_base_detail)__struct.hpp"
+#include "@(include_base)__struct.hpp"
 
 @{
 include_directives = set()

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -2,8 +2,8 @@
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 }@
 @{

--- a/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp-extras.cmake.in
+++ b/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp-extras.cmake.in
@@ -12,6 +12,9 @@ if(NOT FastRTPS_FOUND)
     "Could not find eProsima Fast-RTPS - skip rosidl_typesupport_fastrtps_cpp"
   )
 else()
+  # Make sure extension points are registered in order
+  find_package(rosidl_generator_cpp QUIET)
+
   find_package(ament_cmake_core QUIET REQUIRED)
   ament_register_extension(
     "rosidl_generate_idl_interfaces"

--- a/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp/__init__.py
+++ b/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp/__init__.py
@@ -17,8 +17,9 @@ from rosidl_cmake import generate_files
 
 def generate_cpp(generator_arguments_file):
     mapping = {
-        'idl__rosidl_typesupport_fastrtps_cpp.hpp.em': '%s__rosidl_typesupport_fastrtps_cpp.hpp',
-        'idl__type_support.cpp.em': 'dds_fastrtps/%s__type_support.cpp',
+        'idl__rosidl_typesupport_fastrtps_cpp.hpp.em':
+        'detail/%s__rosidl_typesupport_fastrtps_cpp.hpp',
+        'idl__type_support.cpp.em': 'detail/dds_fastrtps/%s__type_support.cpp',
     }
     generate_files(generator_arguments_file, mapping)
     return 0


### PR DESCRIPTION
Depends on https://github.com/ros2/rosidl/pull/483.