### PR TITLE
QD Security Vulnerability Declaration: REP 2006

### DIFF
--- a/rosidl_typesupport_fastrtps_c/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_fastrtps_c/QUALITY_DECLARATION.md
@@ -138,4 +138,4 @@ Currently nightly results can be seen here:
 
 ## Vulnerability Disclosure Policy [7.i]
 
-This package does not yet have a Vulnerability Disclosure Policy
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rosidl_typesupport_fastrtps_cpp/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_fastrtps_cpp/QUALITY_DECLARATION.md
@@ -136,4 +136,4 @@ Currently nightly results can be seen here:
 
 ## Vulnerability Disclosure Policy [7.i]
 
-This package does not yet have a Vulnerability Disclosure Policy
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).


### PR DESCRIPTION
This PR adds a link to REP-2006 (the Security Vulnerability Declaration) to the Quality Declaration for this repository.

Connects to ros2/ros2#924.