### PR TITLE
use CMake config dirs as hint for header/library search

### DIFF
--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -33,20 +33,23 @@
 
 set(FastRTPS_FOUND FALSE)
 
-find_path(FastRTPS_INCLUDE_DIR
-  NAMES fastrtps/)
-
 find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
 
 string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastcdr_MAJOR_MINOR_VERSION "${fastcdr_VERSION}")
 string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastrtps_MAJOR_MINOR_VERSION "${fastrtps_VERSION}")
 
+find_path(FastRTPS_INCLUDE_DIR
+  NAMES fastrtps/
+  HINTS "${fastrtps_DIR}/../../../include")
+
 find_library(FastCDR_LIBRARY_RELEASE
-  NAMES fastcdr-${fastcdr_MAJOR_MINOR_VERSION} fastcdr)
+  NAMES fastcdr-${fastcdr_MAJOR_MINOR_VERSION} fastcdr
+  HINTS "${fastcdr_DIR}/../..")
 
 find_library(FastCDR_LIBRARY_DEBUG
-  NAMES fastcdrd-${fastcdr_MAJOR_MINOR_VERSION})
+  NAMES fastcdrd-${fastcdr_MAJOR_MINOR_VERSION}
+  HINTS "${fastcdr_DIR}/../..")
 
 if(FastCDR_LIBRARY_RELEASE AND FastCDR_LIBRARY_DEBUG)
   set(FastCDR_LIBRARIES
@@ -66,10 +69,12 @@ else()
 endif()
 
 find_library(FastRTPS_LIBRARY_RELEASE
-  NAMES fastrtps-${fastrtps_MAJOR_MINOR_VERSION} fastrtps)
+  NAMES fastrtps-${fastrtps_MAJOR_MINOR_VERSION} fastrtps
+  HINTS "${fastrtps_DIR}/../../../lib")
 
 find_library(FastRTPS_LIBRARY_DEBUG
-  NAMES fastrtpsd-${fastrtps_MAJOR_MINOR_VERSION})
+  NAMES fastrtpsd-${fastrtps_MAJOR_MINOR_VERSION}
+  HINTS "${fastrtps_DIR}/../../../lib")
 
 if(FastRTPS_LIBRARY_RELEASE AND FastRTPS_LIBRARY_DEBUG)
   set(FastRTPS_LIBRARIES


### PR DESCRIPTION
Follow up of ros2/ros2#943.

Allows plain CMake packages to build while calling `find_package()` something which recursively needs FastRTPS (without manually setting the `CMAKE_PREFIX_PATH` to the `AMENT_PREFIX_PATH`).

@gbiggs @hdino FYI

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12673)](http://ci.ros2.org/job/ci_linux/12673/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7636)](http://ci.ros2.org/job/ci_linux-aarch64/7636/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10388)](http://ci.ros2.org/job/ci_osx/10388/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12610)](http://ci.ros2.org/job/ci_windows/12610/)