### PR TITLE
Fastdds type support extensions

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
@@ -34,6 +34,7 @@ size_t get_serialized_size_@('__'.join([package_name] + list(interface_path.pare
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
 size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
   bool & full_bounded,
+  bool & is_plain,
   size_t current_alignment);
 
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -518,8 +518,9 @@ size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.pare
   const size_t wchar_size = 4;
   (void)padding;
   (void)wchar_size;
-  (void)full_bounded;
-  (void)is_plain;
+  
+  full_bounded = true;
+  is_plain = true;
 
 @[for member in message.structure.members]@
   // member: @(member.name)
@@ -583,9 +584,13 @@ if isinstance(type_, AbstractNestedType):
 @[    end if]@
 @[  else]
     for (size_t index = 0; index < array_size; ++index) {
+      bool inner_full_bounded;
+      bool inner_is_plain;
       current_alignment +=
         max_serialized_size_@('__'.join(type_.namespaced_name()))(
-        full_bounded, is_plain, current_alignment);
+        inner_full_bounded, inner_is_plain, current_alignment);
+      full_bounded &= inner_full_bounded;
+      is_plain &= inner_is_plain;
     }
 @[  end if]@
   }
@@ -596,11 +601,6 @@ if isinstance(type_, AbstractNestedType):
 
 static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
 {
-  // Start considering the type is plain.
-  // Internal methods will set values to false when necessary.
-  full_bounded = true;
-  is_plain = true;
-
   return max_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
     full_bounded, is_plain, 0);
 }

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -134,6 +134,7 @@ ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
 @[  end if]@
 size_t max_serialized_size_@('__'.join(key))(
   bool & full_bounded,
+  bool & is_plain,
   size_t current_alignment);
 
 @[  if key[0] != package_name]@
@@ -508,6 +509,7 @@ static uint32_t _@(message.structure.namespaced_type.name)__get_serialized_size(
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
 size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
   bool & full_bounded,
+  bool & is_plain,
   size_t current_alignment)
 {
   size_t initial_alignment = current_alignment;
@@ -517,6 +519,7 @@ size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.pare
   (void)padding;
   (void)wchar_size;
   (void)full_bounded;
+  (void)is_plain;
 
 @[for member in message.structure.members]@
   // member: @(member.name)
@@ -526,11 +529,13 @@ size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.pare
     size_t array_size = @(member.type.size);
 @[    elif isinstance(member.type, BoundedSequence)]@
     size_t array_size = @(member.type.maximum_size);
+    is_plain = false;
 @[    else]@
     size_t array_size = 0;
 @[    end if]@
 @[    if isinstance(member.type, AbstractSequence)]@
     full_bounded = false;
+    is_plain = false;
     current_alignment += padding +
       eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
 @[    end if]@
@@ -545,6 +550,7 @@ if isinstance(type_, AbstractNestedType):
 }@
 @[  if isinstance(type_, AbstractGenericString)]@
     full_bounded = false;
+    is_plain = false;
     for (size_t index = 0; index < array_size; ++index) {
       current_alignment += padding +
         eprosima::fastcdr::Cdr::alignment(current_alignment, padding) +
@@ -579,7 +585,7 @@ if isinstance(type_, AbstractNestedType):
     for (size_t index = 0; index < array_size; ++index) {
       current_alignment +=
         max_serialized_size_@('__'.join(type_.namespaced_name()))(
-        full_bounded, current_alignment);
+        full_bounded, is_plain, current_alignment);
     }
 @[  end if]@
   }
@@ -588,10 +594,10 @@ if isinstance(type_, AbstractNestedType):
   return current_alignment - initial_alignment;
 }
 
-static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded)
+static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
 {
   return max_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-    full_bounded, 0);
+    full_bounded, is_plain, 0);
 }
 
 @

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -596,6 +596,11 @@ if isinstance(type_, AbstractNestedType):
 
 static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
 {
+  // Start considering the type is plain.
+  // Internal methods will set values to false when necessary.
+  full_bounded = true;
+  is_plain = true;
+
   return max_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
     full_bounded, is_plain, 0);
 }

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -599,10 +599,19 @@ if isinstance(type_, AbstractNestedType):
   return current_alignment - initial_alignment;
 }
 
-static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
+static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(char & bounds_info)
 {
-  return max_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
+  bool full_bounded;
+  bool is_plain;
+  size_t ret_val;
+
+  ret_val = max_serialized_size_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
     full_bounded, is_plain, 0);
+
+  bounds_info =
+    is_plain ? ROSIDL_TYPESUPPORT_FASTRTPS_PLAIN_TYPE :
+    full_bounded ? ROSIDL_TYPESUPPORT_FASTRTPS_BOUNDED_TYPE : ROSIDL_TYPESUPPORT_FASTRTPS_UNBOUNDED_TYPE;
+  return ret_val;
 }
 
 @

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -518,7 +518,7 @@ size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.pare
   const size_t wchar_size = 4;
   (void)padding;
   (void)wchar_size;
-  
+
   full_bounded = true;
   is_plain = true;
 

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -22,6 +22,10 @@
 /// Feature define to allow API version detection
 #define ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
 
+#define ROSIDL_TYPESUPPORT_FASTRTPS_UNBOUNDED_TYPE 0x00
+#define ROSIDL_TYPESUPPORT_FASTRTPS_BOUNDED_TYPE   0x01
+#define ROSIDL_TYPESUPPORT_FASTRTPS_PLAIN_TYPE     0x03
+
 /// Encapsulates the callbacks for getting properties of this rosidl type.
 /**
  * These callbacks are implemented in the generated sources.
@@ -63,12 +67,15 @@ typedef struct message_type_support_callbacks_t
   /// Callback function to determine the maximum size needed for serialization, which is used for
   /// type support initialization.
   /**
-   * \param[out] full_bounded Whether the maximum serialized size was fully bounded,
-   *  (i.e. not unbounded strings or sequences).
-   * \param[out] is_plain Whether the type is plain (i.e. does not have strings or sequences).
+   * \param[out] bounds_info Bounds information for the type.
+   *                         May return one of the following values:
+   *                         - \c ROSIDL_TYPESUPPORT_FASTRTPS_PLAIN_TYPE for POD types
+   *                         - \c ROSIDL_TYPESUPPORT_FASTRTPS_BOUNDED_TYPE for fully bounded types,
+   *                           (i.e. not unbounded strings or sequences).
+   *                         - \c ROSIDL_TYPESUPPORT_FASTRTPS_UNBOUNDED_TYPE for unbounded types
    * \return The maximum serialized size, in bytes.
    */
-  size_t (* max_serialized_size)(bool & full_bounded, bool & is_plain);
+  size_t (* max_serialized_size)(char & bounds_info);
 } message_type_support_callbacks_t;
 
 #endif  // ROSIDL_TYPESUPPORT_FASTRTPS_CPP__MESSAGE_TYPE_SUPPORT_H_

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -19,6 +19,9 @@
 
 #include <fastcdr/Cdr.h>
 
+/// Feature define to allow API version detection
+#define ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
+
 /// Encapsulates the callbacks for getting properties of this rosidl type.
 /**
  * These callbacks are implemented in the generated sources.

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -60,11 +60,12 @@ typedef struct message_type_support_callbacks_t
   /// Callback function to determine the maximum size needed for serialization, which is used for
   /// type support initialization.
   /**
-   * \param[out] Whether the maximum serialized size was fully bounded, (i.e. not unbounded strings
-   *  or sequences).
+   * \param[out] full_bounded Whether the maximum serialized size was fully bounded,
+   *  (i.e. not unbounded strings or sequences).
+   * \param[out] is_plain Whether the type is plain (i.e. does not have strings or sequences).
    * \return The maximum serialized size, in bytes.
    */
-  size_t (* max_serialized_size)(bool & full_bounded);
+  size_t (* max_serialized_size)(bool & full_bounded, bool & is_plain);
 } message_type_support_callbacks_t;
 
 #endif  // ROSIDL_TYPESUPPORT_FASTRTPS_CPP__MESSAGE_TYPE_SUPPORT_H_

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__rosidl_typesupport_fastrtps_cpp.hpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__rosidl_typesupport_fastrtps_cpp.hpp.em
@@ -80,6 +80,7 @@ size_t
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_@(package_name)
 max_serialized_size_@(message.structure.namespaced_type.name)(
   bool & full_bounded,
+  bool & is_plain,
   size_t current_alignment);
 
 }  // namespace typesupport_fastrtps_cpp

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -356,8 +356,9 @@ max_serialized_size_@(message.structure.namespaced_type.name)(
   const size_t wchar_size = 4;
   (void)padding;
   (void)wchar_size;
-  (void)full_bounded;
-  (void)is_plain;
+  
+  full_bounded = true;
+  is_plain = true;
 
 @[for member in message.structure.members]@
 
@@ -422,9 +423,13 @@ if isinstance(type_, AbstractNestedType):
 @[    end if]@
 @[  else]
     for (size_t index = 0; index < array_size; ++index) {
+      bool inner_full_bounded;
+      bool inner_is_plain;
       current_alignment +=
         @('::'.join(type_.namespaces))::typesupport_fastrtps_cpp::max_serialized_size_@(type_.name)(
-        full_bounded, is_plain, current_alignment);
+        inner_full_bounded, inner_is_plain, current_alignment);
+      full_bounded &= inner_full_bounded;
+      is_plain &= inner_is_plain;
     }
 @[  end if]@
   }
@@ -464,11 +469,6 @@ static uint32_t _@(message.structure.namespaced_type.name)__get_serialized_size(
 
 static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
 {
-  // Start considering the type is plain.
-  // Internal methods will set values to false when necessary.
-  full_bounded = true;
-  is_plain = true;
-
   return max_serialized_size_@(message.structure.namespaced_type.name)(full_bounded, is_plain, 0);
 }
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -467,9 +467,18 @@ static uint32_t _@(message.structure.namespaced_type.name)__get_serialized_size(
   return static_cast<uint32_t>(get_serialized_size(*typed_message, 0));
 }
 
-static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
+static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(char & bounds_info)
 {
-  return max_serialized_size_@(message.structure.namespaced_type.name)(full_bounded, is_plain, 0);
+  bool full_bounded;
+  bool is_plain;
+  size_t ret_val;
+
+  ret_val = max_serialized_size_@(message.structure.namespaced_type.name)(full_bounded, is_plain, 0);
+
+  bounds_info =
+    is_plain ? ROSIDL_TYPESUPPORT_FASTRTPS_PLAIN_TYPE :
+    full_bounded ? ROSIDL_TYPESUPPORT_FASTRTPS_BOUNDED_TYPE : ROSIDL_TYPESUPPORT_FASTRTPS_UNBOUNDED_TYPE;
+  return ret_val;
 }
 
 static message_type_support_callbacks_t _@(message.structure.namespaced_type.name)__callbacks = {

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -62,6 +62,7 @@ size_t get_serialized_size(
 size_t
 max_serialized_size_@(type_.name)(
   bool & full_bounded,
+  bool & is_plain,
   size_t current_alignment);
 }  // namespace typesupport_fastrtps_cpp
 @[    for ns in reversed(type_.namespaces)]@
@@ -346,6 +347,7 @@ size_t
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_@(package_name)
 max_serialized_size_@(message.structure.namespaced_type.name)(
   bool & full_bounded,
+  bool & is_plain,
   size_t current_alignment)
 {
   size_t initial_alignment = current_alignment;
@@ -355,6 +357,7 @@ max_serialized_size_@(message.structure.namespaced_type.name)(
   (void)padding;
   (void)wchar_size;
   (void)full_bounded;
+  (void)is_plain;
 
 @[for member in message.structure.members]@
 
@@ -365,11 +368,13 @@ max_serialized_size_@(message.structure.namespaced_type.name)(
     size_t array_size = @(member.type.size);
 @[    elif isinstance(member.type, BoundedSequence)]@
     size_t array_size = @(member.type.maximum_size);
+    is_plain = false;
 @[    else]@
     size_t array_size = 0;
 @[    end if]@
 @[    if isinstance(member.type, AbstractSequence)]@
     full_bounded = false;
+    is_plain = false;
     current_alignment += padding +
       eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
 @[    end if]@
@@ -384,6 +389,7 @@ if isinstance(type_, AbstractNestedType):
 }@
 @[  if isinstance(type_, AbstractGenericString)]@
     full_bounded = false;
+    is_plain = false;
     for (size_t index = 0; index < array_size; ++index) {
       current_alignment += padding +
         eprosima::fastcdr::Cdr::alignment(current_alignment, padding) +
@@ -418,7 +424,7 @@ if isinstance(type_, AbstractNestedType):
     for (size_t index = 0; index < array_size; ++index) {
       current_alignment +=
         @('::'.join(type_.namespaces))::typesupport_fastrtps_cpp::max_serialized_size_@(type_.name)(
-        full_bounded, current_alignment);
+        full_bounded, is_plain, current_alignment);
     }
 @[  end if]@
   }
@@ -456,9 +462,9 @@ static uint32_t _@(message.structure.namespaced_type.name)__get_serialized_size(
   return static_cast<uint32_t>(get_serialized_size(*typed_message, 0));
 }
 
-static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded)
+static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
 {
-  return max_serialized_size_@(message.structure.namespaced_type.name)(full_bounded, 0);
+  return max_serialized_size_@(message.structure.namespaced_type.name)(full_bounded, is_plain, 0);
 }
 
 static message_type_support_callbacks_t _@(message.structure.namespaced_type.name)__callbacks = {

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -464,6 +464,11 @@ static uint32_t _@(message.structure.namespaced_type.name)__get_serialized_size(
 
 static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(bool & full_bounded, bool & is_plain)
 {
+  // Start considering the type is plain.
+  // Internal methods will set values to false when necessary.
+  full_bounded = true;
+  is_plain = true;
+
   return max_serialized_size_@(message.structure.namespaced_type.name)(full_bounded, is_plain, 0);
 }
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -356,7 +356,7 @@ max_serialized_size_@(message.structure.namespaced_type.name)(
   const size_t wchar_size = 4;
   (void)padding;
   (void)wchar_size;
-  
+
   full_bounded = true;
   is_plain = true;
 


### PR DESCRIPTION
This extends the initialization callback `max_serialized_size` so it returns whether the type support refers to a POD type.

This change is required in order to support zero-copy on rmw_fastrtps_cpp.

Connects to ros2/rmw_fastrtps#516
Connects to ros2/rmw_connextdds#14