### PR TITLE
Remove fastrtps dependency

### DIFF
--- a/rosidl_typesupport_fastrtps_c/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_c/CMakeLists.txt
@@ -28,8 +28,6 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(fastrtps_cmake_module REQUIRED)
 find_package(fastcdr REQUIRED CONFIG)
-find_package(fastrtps REQUIRED CONFIG)
-find_package(FastRTPS REQUIRED MODULE)
 if(FASTRTPS_STATIC_DISABLE)
   ament_package()
   message(STATUS "fastrtps static rmw implementation explicitly disabled - skipping '${PROJECT_NAME}'")

--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -15,8 +15,6 @@
 find_package(ament_cmake_ros REQUIRED)
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
-find_package(fastrtps REQUIRED CONFIG)
-find_package(FastRTPS REQUIRED MODULE)
 
 set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c/${PROJECT_NAME}")
 set(_generated_files "")
@@ -90,7 +88,7 @@ configure_file(
 
 set(_target_suffix "__rosidl_typesupport_fastrtps_c")
 
-link_directories(${fastrtps_LIBRARY_DIRS})
+link_directories(${fastcdr_LIBRARY_DIRS})
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${_generated_files})
 if(rosidl_generate_interfaces_LIBRARY_NAME)
@@ -100,7 +98,7 @@ endif()
 set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PROPERTIES CXX_STANDARD 14)
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  "fastrtps"
+  "fastcdr"
   "rmw"
   "rosidl_runtime_c"
   "rosidl_typesupport_fastrtps_cpp"
@@ -129,7 +127,7 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp
 )
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  "fastrtps"
+  "fastcdr"
   "rosidl_typesupport_fastrtps_cpp"
   "rosidl_typesupport_fastrtps_c"
 )

--- a/rosidl_typesupport_fastrtps_c/package.xml
+++ b/rosidl_typesupport_fastrtps_c/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>fastrtps_cmake_module</buildtool_depend>
   <buildtool_depend>fastcdr</buildtool_depend>
-  <buildtool_depend>fastrtps</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_runtime_c</buildtool_depend>
   <buildtool_depend>rosidl_typesupport_fastrtps_cpp</buildtool_depend>
@@ -20,7 +19,6 @@
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>fastrtps_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>fastcdr</buildtool_export_depend>
-  <buildtool_export_depend>fastrtps</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_parser</buildtool_export_depend>
   <buildtool_export_depend>rosidl_runtime_c</buildtool_export_depend>

--- a/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c-extras.cmake.in
+++ b/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c-extras.cmake.in
@@ -6,7 +6,7 @@ find_package(fastcdr REQUIRED CONFIG)
 
 if(NOT fastcdr_FOUND)
   message(STATUS
-    "Could not find eProsima fastcdr: skipping rosidl_typesupport_fastrtps_c"
+    "Could not find eProsima Fast CDR: skipping rosidl_typesupport_fastrtps_c"
   )
 else()
   find_package(ament_cmake_core QUIET REQUIRED)

--- a/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c-extras.cmake.in
+++ b/rosidl_typesupport_fastrtps_c/rosidl_typesupport_fastrtps_c-extras.cmake.in
@@ -3,12 +3,10 @@
 
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
-find_package(fastrtps REQUIRED CONFIG)
-find_package(FastRTPS REQUIRED MODULE)
 
-if(NOT FastRTPS_FOUND)
+if(NOT fastcdr_FOUND)
   message(STATUS
-    "Could not find eProsima Fast-RTPS: skipping rosidl_typesupport_fastrtps_c"
+    "Could not find eProsima fastcdr: skipping rosidl_typesupport_fastrtps_c"
   )
 else()
   find_package(ament_cmake_core QUIET REQUIRED)

--- a/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
@@ -23,8 +23,6 @@ find_package(ament_cmake REQUIRED)
 
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
-find_package(fastrtps REQUIRED CONFIG)
-find_package(FastRTPS REQUIRED MODULE)
 if(FASTRTPS_STATIC_DISABLE)
   ament_package()
   message(STATUS "fastrtps static rmw implementation explicitly disabled - skipping '${PROJECT_NAME}'")
@@ -33,7 +31,6 @@ endif()
 
 find_package(ament_cmake_python REQUIRED)
 
-ament_export_dependencies(fastrtps)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_runtime_c)

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -15,8 +15,6 @@
 find_package(ament_cmake_ros REQUIRED)
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
-find_package(fastrtps REQUIRED CONFIG)
-find_package(FastRTPS REQUIRED MODULE)
 
 
 set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp/${PROJECT_NAME}")
@@ -141,7 +139,7 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  "fastrtps"
+  "fastcdr"
   "rmw"
   "rosidl_runtime_c"
   "rosidl_typesupport_fastrtps_cpp"
@@ -157,7 +155,7 @@ endforeach()
 
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_cpp
-  fastrtps fastcdr)
+  fastcdr)
 
 # Make top level generation target depend on this library
 add_dependencies(

--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>fastrtps_cmake_module</buildtool_depend>
   <buildtool_depend>fastcdr</buildtool_depend>
-  <buildtool_depend>fastrtps</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_runtime_c</buildtool_depend>
   <buildtool_depend>rosidl_runtime_cpp</buildtool_depend>
@@ -20,7 +19,6 @@
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>fastrtps_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>fastcdr</buildtool_export_depend>
-  <buildtool_export_depend>fastrtps</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_parser</buildtool_export_depend>
   <buildtool_export_depend>rosidl_runtime_c</buildtool_export_depend>

--- a/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp-extras.cmake.in
+++ b/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp-extras.cmake.in
@@ -4,12 +4,10 @@
 
 find_package(fastrtps_cmake_module QUIET)
 find_package(fastcdr REQUIRED CONFIG)
-find_package(fastrtps REQUIRED CONFIG)
-find_package(FastRTPS REQUIRED MODULE)
 
-if(NOT FastRTPS_FOUND)
+if(NOT fastcdr_FOUND)
   message(STATUS
-    "Could not find eProsima Fast-RTPS - skip rosidl_typesupport_fastrtps_cpp"
+    "Could not find eProsima fastcdr - skip rosidl_typesupport_fastrtps_cpp"
   )
 else()
   find_package(ament_cmake_core QUIET REQUIRED)

--- a/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp-extras.cmake.in
+++ b/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp-extras.cmake.in
@@ -7,7 +7,7 @@ find_package(fastcdr REQUIRED CONFIG)
 
 if(NOT fastcdr_FOUND)
   message(STATUS
-    "Could not find eProsima fastcdr - skip rosidl_typesupport_fastrtps_cpp"
+    "Could not find eProsima Fast CDR - skip rosidl_typesupport_fastrtps_cpp"
   )
 else()
   find_package(ament_cmake_core QUIET REQUIRED)


### PR DESCRIPTION
This PR updates packages `rosidl_typesupport_fastrtps_c` and `rosidl_typesupport_fastrtps_cpp` to remove their dependency from `fastrtps`, since they only require the `fastcdr` libraries.

This change should allow `rmw_connextdds` (which also relies on these type supports) to avoid an indirect dependency on `fastrtps`.