### PR TITLE
Correctly inform that a BoundedSequence is bounded

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -530,12 +530,11 @@ size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.pare
     size_t array_size = @(member.type.size);
 @[    elif isinstance(member.type, BoundedSequence)]@
     size_t array_size = @(member.type.maximum_size);
-    is_plain = false;
 @[    else]@
     size_t array_size = 0;
+    full_bounded = false;
 @[    end if]@
 @[    if isinstance(member.type, AbstractSequence)]@
-    full_bounded = false;
     is_plain = false;
     current_alignment += padding +
       eprosima::fastcdr::Cdr::alignment(current_alignment, padding);

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -369,12 +369,11 @@ max_serialized_size_@(message.structure.namespaced_type.name)(
     size_t array_size = @(member.type.size);
 @[    elif isinstance(member.type, BoundedSequence)]@
     size_t array_size = @(member.type.maximum_size);
-    is_plain = false;
 @[    else]@
     size_t array_size = 0;
+    full_bounded = false;
 @[    end if]@
 @[    if isinstance(member.type, AbstractSequence)]@
-    full_bounded = false;
     is_plain = false;
     current_alignment += padding +
       eprosima::fastcdr::Cdr::alignment(current_alignment, padding);


### PR DESCRIPTION
This PR fixes a mistake I made on #67, that made bounded sequences be treated as unbounded ones.

The full fix also needs ros2/rmw_fastrtps#540, so that serialization sizes are calculated correctly.