### PR TITLE
Fix Fast-RTPS C++ typesupport CLI extension

### DIFF
--- a/rosidl_typesupport_fastrtps_c/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_c/CMakeLists.txt
@@ -106,6 +106,9 @@ if(BUILD_TESTING)
   if(TARGET benchmark_string_conversions)
     target_link_libraries(benchmark_string_conversions ${PROJECT_NAME})
   endif()
+
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_cli_extension test/test_cli_extension.py)
 endif()
 
 ament_package(

--- a/rosidl_typesupport_fastrtps_c/package.xml
+++ b/rosidl_typesupport_fastrtps_c/package.xml
@@ -32,6 +32,7 @@
   <exec_depend>rosidl_typesupport_interface</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>

--- a/rosidl_typesupport_fastrtps_c/test/msg/Test.msg
+++ b/rosidl_typesupport_fastrtps_c/test/msg/Test.msg
@@ -1,0 +1,1 @@
+string test

--- a/rosidl_typesupport_fastrtps_c/test/test_cli_extension.py
+++ b/rosidl_typesupport_fastrtps_c/test/test_cli_extension.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from rosidl_cli.command.generate.api import generate
+
+TEST_DIR = str(pathlib.Path(__file__).parent)
+
+
+def test_cli_extension_for_smoke(tmp_path):
+    assert len(generate(
+        package_name='rosidl_typesupport_fastrtps_c',
+        interface_files=[TEST_DIR + ':msg/Test.msg'],
+        typesupports=['fastrtps_c'],
+        output_path=tmp_path
+    )) > 0

--- a/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_cpp/CMakeLists.txt
@@ -100,6 +100,9 @@ if(BUILD_TESTING)
   if(TARGET benchmark_string_conversions)
     target_link_libraries(benchmark_string_conversions ${PROJECT_NAME})
   endif()
+
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_cli_extension test/test_cli_extension.py)
 endif()
 
 ament_package(

--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -33,6 +33,7 @@
   <exec_depend>rosidl_typesupport_interface</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>

--- a/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp/__init__.py
+++ b/rosidl_typesupport_fastrtps_cpp/rosidl_typesupport_fastrtps_cpp/__init__.py
@@ -21,5 +21,4 @@ def generate_cpp(generator_arguments_file):
         'detail/%s__rosidl_typesupport_fastrtps_cpp.hpp',
         'idl__type_support.cpp.em': 'detail/dds_fastrtps/%s__type_support.cpp',
     }
-    generate_files(generator_arguments_file, mapping)
-    return 0
+    return generate_files(generator_arguments_file, mapping)

--- a/rosidl_typesupport_fastrtps_cpp/test/msg/Test.msg
+++ b/rosidl_typesupport_fastrtps_cpp/test/msg/Test.msg
@@ -1,0 +1,1 @@
+string test

--- a/rosidl_typesupport_fastrtps_cpp/test/test_cli_extension.py
+++ b/rosidl_typesupport_fastrtps_cpp/test/test_cli_extension.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from rosidl_cli.command.generate.api import generate
+
+TEST_DIR = str(pathlib.Path(__file__).parent)
+
+
+def test_cli_extension_for_smoke(tmp_path):
+    assert len(generate(
+        package_name='rosidl_typesupport_fastrtps_cpp',
+        interface_files=[TEST_DIR + ':msg/Test.msg'],
+        typesupports=['fastrtps_cpp'],
+        output_path=tmp_path
+    )) > 0


### PR DESCRIPTION
Precisely what the title says. This PR also adds some smoke tests to detect future regression.

CI up to `rosidl_typesupport_fastrtps_c*`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14786)](http://ci.ros2.org/job/ci_linux/14786/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9535)](http://ci.ros2.org/job/ci_linux-aarch64/9535/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12452)](http://ci.ros2.org/job/ci_osx/12452/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14933)](http://ci.ros2.org/job/ci_windows/14933/)
