### PR TITLE
Revert rosidl targets and dependencies exportation (#73, #75) 

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -121,8 +121,10 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PROPERTIES COMPILE_FLAGS "${_target_compile_flags}")
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c>"
-  "$<INSTALL_INTERFACE:include>"
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp
 )
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "fastcdr"
@@ -137,7 +139,7 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   normalize_path(_srv_include_dir "${_srv_include_dir}")
   normalize_path(_action_include_dir "${_action_include_dir}")
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    PRIVATE
+    PUBLIC
     "${_msg_include_dir}"
     "${_srv_include_dir}"
     "${_action_include_dir}"
@@ -149,7 +151,6 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
 endforeach()
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
-  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_cpp
   ${rosidl_generate_interfaces_TARGET}__rosidl_typesupport_fastrtps_cpp)
 
 add_dependencies(
@@ -178,13 +179,12 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
 
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    EXPORT ${rosidl_generate_interfaces_TARGET}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
 
-  rosidl_export_typesupport_targets(${_target_suffix}
+  rosidl_export_typesupport_libraries(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 

--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -124,6 +124,11 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c>"
   "$<INSTALL_INTERFACE:include>"
 )
+ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  "fastcdr"
+  "rosidl_typesupport_fastrtps_cpp"
+  "rosidl_typesupport_fastrtps_c"
+)
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   set(_msg_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/msg/dds_fastrtps_c")
   set(_srv_include_dir "${${_pkg_name}_DIR}/../../../include/${_pkg_name}/srv/dds_fastrtps_c")
@@ -159,13 +164,6 @@ add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__cpp
 )
-ament_export_dependencies(
-  "fastcdr"
-  "rmw"
-  "rosidl_runtime_c"
-  "rosidl_typesupport_fastrtps_cpp"
-  "rosidl_typesupport_fastrtps_c"
-  "rosidl_typesupport_interface")
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   install(

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -168,12 +168,6 @@ add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__cpp
 )
-ament_export_dependencies(
-  "fastcdr"
-  "rmw"
-  "rosidl_runtime_c"
-  "rosidl_typesupport_fastrtps_cpp"
-  "rosidl_typesupport_interface")
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   install(

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -134,8 +134,8 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 # Include headers from other generators
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp>"
-  "$<INSTALL_INTERFACE:include>"
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp
 )
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
@@ -182,13 +182,12 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
 
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    EXPORT ${rosidl_generate_interfaces_TARGET}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
 
-  rosidl_export_typesupport_targets(${_target_suffix}
+  rosidl_export_typesupport_libraries(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 


### PR DESCRIPTION
Precisely what the title says. This patch rolls back #73 and #75, as these are incompatible with how ROS 2 binaries are built. 