### PR TITLE
Use FindPython3 explicitly instead of PythonInterp implicitly

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -67,9 +67,12 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 add_custom_command(
   OUTPUT ${_generated_files}
-  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_fastrtps_c_BIN}
+  COMMAND Python3::Interpreter
+  ARGS ${rosidl_typesupport_fastrtps_c_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   DEPENDS ${target_dependencies}
   COMMENT "Generating C type support for eProsima Fast-RTPS"

--- a/rosidl_typesupport_fastrtps_c/package.xml
+++ b/rosidl_typesupport_fastrtps_c/package.xml
@@ -19,6 +19,7 @@
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>fastrtps_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>fastcdr</buildtool_export_depend>
+  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_parser</buildtool_export_depend>
   <buildtool_export_depend>rosidl_runtime_c</buildtool_export_depend>

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -77,10 +77,13 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 # Add a command that invokes generator at build time
 add_custom_command(
   OUTPUT ${_generated_files}
-  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_fastrtps_cpp_BIN}
+  COMMAND Python3::Interpreter
+  ARGS ${rosidl_typesupport_fastrtps_cpp_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   DEPENDS ${target_dependencies}
   COMMENT "Generating C++ type support for eProsima Fast-RTPS"

--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -19,6 +19,7 @@
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>fastrtps_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>fastcdr</buildtool_export_depend>
+  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_parser</buildtool_export_depend>
   <buildtool_export_depend>rosidl_runtime_c</buildtool_export_depend>


### PR DESCRIPTION
Replaces #77 
Alternative to https://github.com/ros2/rosidl/pull/615
Same reasoning as https://github.com/ros2/rosidl_typesupport/pull/118