### PR TITLE
Improve serialization of primitive bounded sequences in C++ type support

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -122,7 +122,7 @@ cdr_serialize(
     cdr << ros_message.@(member.name);
 @[      else]@
     cdr << static_cast<uint32_t>(size);
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar',)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
     cdr.serializeArray(&(ros_message.@(member.name)[0]), size);
 @[        else]@
 @[            if isinstance(member.type.value_type, AbstractWString)]@
@@ -209,7 +209,7 @@ cdr_deserialize(
     cdr >> cdrSize;
     size_t size = static_cast<size_t>(cdrSize);
     ros_message.@(member.name).resize(size);
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar',)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
     cdr.deserializeArray(&(ros_message.@(member.name)[0]), size);
 @[        else]@
 @[            if isinstance(member.type.value_type, AbstractWString)]@

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -122,25 +122,29 @@ cdr_serialize(
     cdr << ros_message.@(member.name);
 @[      else]@
     cdr << static_cast<uint32_t>(size);
-@[        if isinstance(member.type.value_type, AbstractWString)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar',)]@
+    cdr.serializeArray(&(ros_message.@(member.name)[0]), size);
+@[        else]@
+@[            if isinstance(member.type.value_type, AbstractWString)]@
     std::wstring wstr;
-@[        end if]@
+@[            end if]@
     for (size_t i = 0; i < size; i++) {
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
+@[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       cdr << (ros_message.@(member.name)[i] ? true : false);
-@[        elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+@[            elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
       cdr << static_cast<wchar_t>(ros_message.@(member.name)[i]);
-@[        elif isinstance(member.type.value_type, AbstractWString)]@
+@[            elif isinstance(member.type.value_type, AbstractWString)]@
       rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(ros_message.@(member.name)[i], wstr);
       cdr << wstr;
-@[        elif not isinstance(member.type.value_type, NamespacedType)]@
+@[            elif not isinstance(member.type.value_type, NamespacedType)]@
       cdr << ros_message.@(member.name)[i];
-@[        else]@
+@[            else]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_serialize(
         ros_message.@(member.name)[i],
         cdr);
-@[        end if]@
+@[            end if]@
     }
+@[        end if]@
 @[      end if]@
 @[    end if]@
   }
@@ -205,32 +209,36 @@ cdr_deserialize(
     cdr >> cdrSize;
     size_t size = static_cast<size_t>(cdrSize);
     ros_message.@(member.name).resize(size);
-@[        if isinstance(member.type.value_type, AbstractWString)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar',)]@
+    cdr.deserializeArray(&(ros_message.@(member.name)[0]), size);
+@[        else]@
+@[            if isinstance(member.type.value_type, AbstractWString)]@
     std::wstring wstr;
-@[        end if]@
+@[            end if]@
     for (size_t i = 0; i < size; i++) {
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
+@[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       uint8_t tmp;
       cdr >> tmp;
       ros_message.@(member.name)[i] = tmp ? true : false;
-@[        elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+@[            elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
       wchar_t tmp;
       cdr >> tmp;
       ros_message.@(member.name)[i] = static_cast<char16_t>(tmp);
-@[        elif isinstance(member.type.value_type, AbstractWString)]@
+@[            elif isinstance(member.type.value_type, AbstractWString)]@
       cdr >> wstr;
       bool succeeded = rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstr, ros_message.@(member.name)[i]);
       if (!succeeded) {
         fprintf(stderr, "failed to create wstring from u16string\n");
         return false;
       }
-@[        elif not isinstance(member.type.value_type, NamespacedType)]@
+@[            elif not isinstance(member.type.value_type, NamespacedType)]@
       cdr >> ros_message.@(member.name)[i];
-@[        else]@
+@[            else]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
         cdr, ros_message.@(member.name)[i]);
-@[        end if]@
+@[            end if]@
     }
+@[          end if]@
 @[      end if]@
 @[    end if]@
   }


### PR DESCRIPTION
This PR introduces some minor changes to the C++ message type support templates in order to take advantage of existing functions in Fast CDR for the serialization/deserialization of primitive sequences.

Currently, these are handled via a `for` loop and an element-by-element serialization using the `<<` and `>>` operators. This logic should be improved by the use of `FastCdr::[de]serializeArray()`.

Note that the C message type support already contains these optimizations ([[1]](https://github.com/ros2/rosidl_typesupport_fastrtps/blob/master/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em#L227), [[2]](https://github.com/ros2/rosidl_typesupport_fastrtps/blob/master/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em#L372)).

Changes haven't been run through full CI yet (will do that next if they look good).