### PR TITLE
Revert "Improve serialization of ... (#79)"

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -122,29 +122,25 @@ cdr_serialize(
     cdr << ros_message.@(member.name);
 @[      else]@
     cdr << static_cast<uint32_t>(size);
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
-    cdr.serializeArray(&(ros_message.@(member.name)[0]), size);
-@[        else]@
-@[            if isinstance(member.type.value_type, AbstractWString)]@
+@[        if isinstance(member.type.value_type, AbstractWString)]@
     std::wstring wstr;
-@[            end if]@
+@[        end if]@
     for (size_t i = 0; i < size; i++) {
-@[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       cdr << (ros_message.@(member.name)[i] ? true : false);
-@[            elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+@[        elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
       cdr << static_cast<wchar_t>(ros_message.@(member.name)[i]);
-@[            elif isinstance(member.type.value_type, AbstractWString)]@
+@[        elif isinstance(member.type.value_type, AbstractWString)]@
       rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(ros_message.@(member.name)[i], wstr);
       cdr << wstr;
-@[            elif not isinstance(member.type.value_type, NamespacedType)]@
+@[        elif not isinstance(member.type.value_type, NamespacedType)]@
       cdr << ros_message.@(member.name)[i];
-@[            else]@
+@[        else]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_serialize(
         ros_message.@(member.name)[i],
         cdr);
-@[            end if]@
-    }
 @[        end if]@
+    }
 @[      end if]@
 @[    end if]@
   }
@@ -209,36 +205,32 @@ cdr_deserialize(
     cdr >> cdrSize;
     size_t size = static_cast<size_t>(cdrSize);
     ros_message.@(member.name).resize(size);
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
-    cdr.deserializeArray(&(ros_message.@(member.name)[0]), size);
-@[        else]@
-@[            if isinstance(member.type.value_type, AbstractWString)]@
+@[        if isinstance(member.type.value_type, AbstractWString)]@
     std::wstring wstr;
-@[            end if]@
+@[        end if]@
     for (size_t i = 0; i < size; i++) {
-@[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       uint8_t tmp;
       cdr >> tmp;
       ros_message.@(member.name)[i] = tmp ? true : false;
-@[            elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+@[        elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
       wchar_t tmp;
       cdr >> tmp;
       ros_message.@(member.name)[i] = static_cast<char16_t>(tmp);
-@[            elif isinstance(member.type.value_type, AbstractWString)]@
+@[        elif isinstance(member.type.value_type, AbstractWString)]@
       cdr >> wstr;
       bool succeeded = rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstr, ros_message.@(member.name)[i]);
       if (!succeeded) {
         fprintf(stderr, "failed to create wstring from u16string\n");
         return false;
       }
-@[            elif not isinstance(member.type.value_type, NamespacedType)]@
+@[        elif not isinstance(member.type.value_type, NamespacedType)]@
       cdr >> ros_message.@(member.name)[i];
-@[            else]@
+@[        else]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
         cdr, ros_message.@(member.name)[i]);
-@[            end if]@
+@[        end if]@
     }
-@[          end if]@
 @[      end if]@
 @[    end if]@
   }


### PR DESCRIPTION
This reverts commit b819083079de027f783f389844a949aacfef79cf.

Attempts to address 72 Windows test regressions in the buildfarm.

FYI @asorbini 

I'll wait until I get a CI check that the PR introduces the regressions before removing the draft mode to the PR.