### PR TITLE
Re-introduce improvements to serialization of primitive bounded sequences for C++ type support

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -122,25 +122,31 @@ cdr_serialize(
     cdr << ros_message.@(member.name);
 @[      else]@
     cdr << static_cast<uint32_t>(size);
-@[        if isinstance(member.type.value_type, AbstractWString)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
+    if (size > 0)  {
+      cdr.serializeArray(&(ros_message.@(member.name)[0]), size);
+    }
+@[        else]@
+@[            if isinstance(member.type.value_type, AbstractWString)]@
     std::wstring wstr;
-@[        end if]@
+@[            end if]@
     for (size_t i = 0; i < size; i++) {
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
+@[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       cdr << (ros_message.@(member.name)[i] ? true : false);
-@[        elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+@[            elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
       cdr << static_cast<wchar_t>(ros_message.@(member.name)[i]);
-@[        elif isinstance(member.type.value_type, AbstractWString)]@
+@[            elif isinstance(member.type.value_type, AbstractWString)]@
       rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(ros_message.@(member.name)[i], wstr);
       cdr << wstr;
-@[        elif not isinstance(member.type.value_type, NamespacedType)]@
+@[            elif not isinstance(member.type.value_type, NamespacedType)]@
       cdr << ros_message.@(member.name)[i];
-@[        else]@
+@[            else]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_serialize(
         ros_message.@(member.name)[i],
         cdr);
-@[        end if]@
+@[            end if]@
     }
+@[        end if]@
 @[      end if]@
 @[    end if]@
   }
@@ -205,32 +211,38 @@ cdr_deserialize(
     cdr >> cdrSize;
     size_t size = static_cast<size_t>(cdrSize);
     ros_message.@(member.name).resize(size);
-@[        if isinstance(member.type.value_type, AbstractWString)]@
+@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
+    if (size > 0) {
+      cdr.deserializeArray(&(ros_message.@(member.name)[0]), size);
+    }
+@[        else]@
+@[            if isinstance(member.type.value_type, AbstractWString)]@
     std::wstring wstr;
-@[        end if]@
+@[            end if]@
     for (size_t i = 0; i < size; i++) {
-@[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
+@[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       uint8_t tmp;
       cdr >> tmp;
       ros_message.@(member.name)[i] = tmp ? true : false;
-@[        elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+@[            elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
       wchar_t tmp;
       cdr >> tmp;
       ros_message.@(member.name)[i] = static_cast<char16_t>(tmp);
-@[        elif isinstance(member.type.value_type, AbstractWString)]@
+@[            elif isinstance(member.type.value_type, AbstractWString)]@
       cdr >> wstr;
       bool succeeded = rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstr, ros_message.@(member.name)[i]);
       if (!succeeded) {
         fprintf(stderr, "failed to create wstring from u16string\n");
         return false;
       }
-@[        elif not isinstance(member.type.value_type, NamespacedType)]@
+@[            elif not isinstance(member.type.value_type, NamespacedType)]@
       cdr >> ros_message.@(member.name)[i];
-@[        else]@
+@[            else]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
         cdr, ros_message.@(member.name)[i]);
-@[        end if]@
+@[            end if]@
     }
+@[          end if]@
 @[      end if]@
 @[    end if]@
   }

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -123,7 +123,7 @@ cdr_serialize(
 @[      else]@
     cdr << static_cast<uint32_t>(size);
 @[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
-    if (size > 0)  {
+    if (size > 0) {
       cdr.serializeArray(&(ros_message.@(member.name)[0]), size);
     }
 @[        else]@


### PR DESCRIPTION
This is a follow up to #79, which introduced regressions for `rmw_connextdds` and `rmw_fastrtps`, detected only in Windows Debug builds. Those changes were thus reverted by #80.

This PR proposes the same changes but calls to `[de]serializeArray()` are guarded by a check on the length of the sequence member, which should prevent the previously observed regressions.

Full CI:
- Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15394)](https://ci.ros2.org/job/ci_linux/15394/)
- macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=13081)](https://ci.ros2.org/job/ci_osx/13081/)
- Windows (debug): [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=15609)](https://ci.ros2.org/job/ci_windows/15609/)
- Windows (release): [waiting for debug to finish first]