### PR TITLE
Install generated headers to include/${PROJECT_NAME}

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -134,7 +134,7 @@ target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBL
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_c>"
-  "$<INSTALL_INTERFACE:include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
@@ -150,12 +150,12 @@ add_dependencies(
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   install(
     DIRECTORY "${_output_path}/"
-    DESTINATION "include/${PROJECT_NAME}"
+    DESTINATION "include/${PROJECT_NAME}/${PROJECT_NAME}"
     PATTERN "*.cpp" EXCLUDE
   )
 
   # Export old-style CMake variables
-  ament_export_include_directories("include")
+  ament_export_include_directories("include/${PROJECT_NAME}")
   rosidl_export_typesupport_libraries(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -138,7 +138,7 @@ target_compile_options(${rosidl_generate_interfaces_TARGET}${_target_suffix} PRI
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_fastrtps_cpp>"
-  "$<INSTALL_INTERFACE:include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBLIC
@@ -168,12 +168,12 @@ add_dependencies(
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   install(
     DIRECTORY "${_output_path}/"
-    DESTINATION "include/${PROJECT_NAME}"
+    DESTINATION "include/${PROJECT_NAME}/${PROJECT_NAME}"
     PATTERN "*.cpp" EXCLUDE
   )
 
   # Export old-style CMake variables
-  ament_export_include_directories("include")
+  ament_export_include_directories("include/${PROJECT_NAME}")
   rosidl_export_typesupport_libraries(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 


### PR DESCRIPTION
Requires #87
Part of ros2/ros2#1150
To be merged at the same time as https://github.com/ros2/rosidl/pull/670

This installs generated headers to a unique include directory to prevent include directory search order issues when overriding packages.