### PR TITLE
Expose type hash to typesupport structs (rep2011)

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -629,7 +629,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
 static message_type_support_callbacks_t __callbacks_@(message.structure.namespaced_type.name) = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
-  @('__'.join(message.structure.namespaced_type.namespaced_name()))__TYPE_VERSION_HASH,
+  @('__'.join(message.structure.namespaced_type.namespaced_name()))__TYPE_VERSION_HASH__INIT,
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,
   _@(message.structure.namespaced_type.name)__get_serialized_size,

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -629,7 +629,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
 static message_type_support_callbacks_t __callbacks_@(message.structure.namespaced_type.name) = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
-  _@(message.structure.namespaced_type.name)__TYPE_VERSION_HASH,  // TODO(emersonknapp) maybe maybe maybe
+  @('__'.join(message.structure.namespaced_type.namespaced_name()))__TYPE_VERSION_HASH,
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,
   _@(message.structure.namespaced_type.name)__get_serialized_size,

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -629,6 +629,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
 static message_type_support_callbacks_t __callbacks_@(message.structure.namespaced_type.name) = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
+  _@(message.structure.namespaced_type.name)__TYPE_VERSION_HASH,  // TODO(emersonknapp) maybe maybe maybe
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,
   _@(message.structure.namespaced_type.name)__get_serialized_size,

--- a/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
@@ -54,6 +54,7 @@ extern "C"
 static service_type_support_callbacks_t @(service.namespaced_type.name)__callbacks = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(service.namespaced_type.name)",
+  @('__'.join(service.namespaced_type.namespaced_name()))__TYPE_VERSION_HASH__INIT,
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))_Request)(),
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))_Response)(),
 };

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -16,6 +16,7 @@
 #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP__MESSAGE_TYPE_SUPPORT_H_
 
 #include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/type_hash.h"
 
 #include <fastcdr/Cdr.h>
 
@@ -38,7 +39,7 @@ typedef struct message_type_support_callbacks_t
   /// The typename of this message.
   const char * message_name_;
 
-  const uint8_t * type_hash_;
+  const rosidl_type_hash_t type_hash_;
 
   /// Callback function for message serialization
   /**

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -38,6 +38,8 @@ typedef struct message_type_support_callbacks_t
   /// The typename of this message.
   const char * message_name_;
 
+  const uint8_t * type_hash_;
+
   /// Callback function for message serialization
   /**
    * \param[in] untyped_ros_message Type erased pointer to message instance.

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -15,10 +15,10 @@
 #ifndef ROSIDL_TYPESUPPORT_FASTRTPS_CPP__MESSAGE_TYPE_SUPPORT_H_
 #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP__MESSAGE_TYPE_SUPPORT_H_
 
+#include <fastcdr/Cdr.h>
+
 #include "rosidl_runtime_c/message_type_support_struct.h"
 #include "rosidl_runtime_c/type_hash.h"
-
-#include <fastcdr/Cdr.h>
 
 /// Feature define to allow API version detection
 #define ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
@@ -39,6 +39,7 @@ typedef struct message_type_support_callbacks_t
   /// The typename of this message.
   const char * message_name_;
 
+  /// The hash of the description of the type of this message.
   const rosidl_type_hash_t type_hash_;
 
   /// Callback function for message serialization

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
@@ -28,7 +28,8 @@ typedef struct service_type_support_callbacks_t
   const char * service_namespace_;
   /// The typename of this service.
   const char * service_name_;
-  // TODO(ek)
+  /// The hash of the description of the type of this service.
+  const rosidl_type_hash_t type_hash_;
   /// Pointer to the request message typesupport members.
   const rosidl_message_type_support_t * request_members_;
   /// Pointer to the response message typesupport members.

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
@@ -28,8 +28,6 @@ typedef struct service_type_support_callbacks_t
   const char * service_namespace_;
   /// The typename of this service.
   const char * service_name_;
-  /// TODO(emersonknapp)
-  // const uint8_t * service_type_hash_;
   /// Pointer to the request message typesupport members.
   const rosidl_message_type_support_t * request_members_;
   /// Pointer to the response message typesupport members.

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
@@ -28,6 +28,7 @@ typedef struct service_type_support_callbacks_t
   const char * service_namespace_;
   /// The typename of this service.
   const char * service_name_;
+  // TODO(ek)
   /// Pointer to the request message typesupport members.
   const rosidl_message_type_support_t * request_members_;
   /// Pointer to the response message typesupport members.

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
@@ -28,7 +28,8 @@ typedef struct service_type_support_callbacks_t
   const char * service_namespace_;
   /// The typename of this service.
   const char * service_name_;
-
+  /// TODO(emersonknapp)
+  // const uint8_t * service_type_hash_;
   /// Pointer to the request message typesupport members.
   const rosidl_message_type_support_t * request_members_;
   /// Pointer to the response message typesupport members.

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -495,6 +495,7 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
 static message_type_support_callbacks_t _@(message.structure.namespaced_type.name)__callbacks = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
+  @('::'.join(message.structure.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,
   _@(message.structure.namespaced_type.name)__get_serialized_size,

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -59,6 +59,7 @@ namespace typesupport_fastrtps_cpp
 static service_type_support_callbacks_t _@(service.namespaced_type.name)__callbacks = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(service.namespaced_type.name)",
+  @('::'.join(service.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name + SERVICE_REQUEST_MESSAGE_SUFFIX))(),
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name + SERVICE_RESPONSE_MESSAGE_SUFFIX))(),
 };


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1159
Depends on https://github.com/ros2/rosidl/pull/722

Make the codegen type hash available to typesupport struct for distribution during discovery. See https://github.com/ros2/rmw_fastrtps/pull/671 for usage