### PR TITLE
Mark benchmark _ as UNUSED.

### DIFF
--- a/rosidl_typesupport_fastrtps_c/package.xml
+++ b/rosidl_typesupport_fastrtps_c/package.xml
@@ -47,6 +47,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>
   <test_depend>performance_test_fixture</test_depend>
+  <test_depend>rcutils</test_depend>
 
   <member_of_group>rosidl_typesupport_c_packages</member_of_group>
 

--- a/rosidl_typesupport_fastrtps_c/test/benchmark/benchmark_string_conversions.cpp
+++ b/rosidl_typesupport_fastrtps_c/test/benchmark/benchmark_string_conversions.cpp
@@ -14,6 +14,8 @@
 
 #include <string>
 
+#include "rcutils/macros.h"
+
 #include "rosidl_runtime_c/string_functions.h"
 #include "rosidl_runtime_c/u16string_functions.h"
 
@@ -41,6 +43,7 @@ BENCHMARK_F(PerformanceTest, wstring_to_u16string)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     rosidl_typesupport_fastrtps_c::wstring_to_u16string(wstring, s);
   }
 
@@ -63,6 +66,7 @@ BENCHMARK_F(PerformanceTest, u16string_to_wstring)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     std::wstring actual;
     rosidl_typesupport_fastrtps_c::u16string_to_wstring(s, actual);
   }

--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -47,6 +47,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>
   <test_depend>performance_test_fixture</test_depend>
+  <test_depend>rcutils</test_depend>
 
   <member_of_group>rosidl_typesupport_cpp_packages</member_of_group>
 

--- a/rosidl_typesupport_fastrtps_cpp/test/benchmark/benchmark_string_conversions.cpp
+++ b/rosidl_typesupport_fastrtps_cpp/test/benchmark/benchmark_string_conversions.cpp
@@ -14,6 +14,8 @@
 
 #include <string>
 
+#include "rcutils/macros.h"
+
 #include "rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp"
 
 #include "performance_test_fixture/performance_test_fixture.hpp"
@@ -32,6 +34,7 @@ BENCHMARK_F(PerformanceTest, wstring_to_u16string)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     std::u16string u16string;
     rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstring, u16string);
   }
@@ -44,6 +47,7 @@ BENCHMARK_F(PerformanceTest, u16string_to_wstring)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     std::wstring wstring;
     rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(u16string, wstring);
   }


### PR DESCRIPTION
This just quiets a clang static analysis warning.