### PR TITLE
Type hashes on typesupport (rep2011)

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -1,5 +1,6 @@
 @# Included from rosidl_typesupport_fastrtps_c/resource/idl__type_support_c.cpp.em
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractSequence
@@ -629,7 +630,6 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
 static message_type_support_callbacks_t __callbacks_@(message.structure.namespaced_type.name) = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
-  @('__'.join(message.structure.namespaced_type.namespaced_name()))__TYPE_VERSION_HASH__INIT,
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,
   _@(message.structure.namespaced_type.name)__get_serialized_size,
@@ -640,6 +640,7 @@ static rosidl_message_type_support_t _@(message.structure.namespaced_type.name)_
   rosidl_typesupport_fastrtps_c__identifier,
   &__callbacks_@(message.structure.namespaced_type.name),
   get_message_typesupport_handle_function,
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__TYPE_VERSION_HASH,
 };
 
 const rosidl_message_type_support_t *

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_fastrtps_c/resource/idl__type_support_c.cpp.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractSequence
@@ -9,9 +10,9 @@ from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import ACTION_FEEDBACK_SUFFIX
 from rosidl_parser.definition import ACTION_GOAL_SUFFIX
 from rosidl_parser.definition import ACTION_RESULT_SUFFIX
+from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_RESPONSE_MESSAGE_SUFFIX
-from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
@@ -640,7 +641,7 @@ static rosidl_message_type_support_t _@(message.structure.namespaced_type.name)_
   rosidl_typesupport_fastrtps_c__identifier,
   &__callbacks_@(message.structure.namespaced_type.name),
   get_message_typesupport_handle_function,
-  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__TYPE_VERSION_HASH,
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_HASH_VAR),
 };
 
 const rosidl_message_type_support_t *

--- a/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
@@ -69,6 +69,7 @@ static rosidl_service_type_support_t @(service.namespaced_type.name)__handle = {
   get_service_typesupport_handle_function,
   &_@(service.namespaced_type.name)@(SERVICE_REQUEST_MESSAGE_SUFFIX)__type_support,
   &_@(service.namespaced_type.name)@(SERVICE_RESPONSE_MESSAGE_SUFFIX)__type_support,
+  &_@(service.namespaced_type.name)@(SERVICE_EVENT_MESSAGE_SUFFIX)__type_support,
   ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_CREATE_EVENT_MESSAGE_SYMBOL_NAME(
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
@@ -77,7 +78,6 @@ static rosidl_service_type_support_t @(service.namespaced_type.name)__handle = {
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
   ),
-  &_@(service.namespaced_type.name)@(SERVICE_EVENT_MESSAGE_SUFFIX)__type_support,
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_HASH_VAR),
 };
 

--- a/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
@@ -21,6 +21,7 @@ TEMPLATE(
 }@
 
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
@@ -54,7 +55,6 @@ extern "C"
 static service_type_support_callbacks_t @(service.namespaced_type.name)__callbacks = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(service.namespaced_type.name)",
-  @('__'.join(service.namespaced_type.namespaced_name()))__TYPE_VERSION_HASH__INIT,
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))_Request)(),
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))_Response)(),
 };
@@ -71,7 +71,8 @@ static rosidl_service_type_support_t @(service.namespaced_type.name)__handle = {
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
   ),
-  &_@(service.namespaced_type.name)_Event__type_support
+  &_@(service.namespaced_type.name)_Event__type_support,
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__TYPE_VERSION_HASH,
 };
 
 const rosidl_service_type_support_t *

--- a/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/srv__type_support_c.cpp.em
@@ -22,6 +22,10 @@ TEMPLATE(
 
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_HASH_VAR
+from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
+from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
+from rosidl_parser.definition import SERVICE_RESPONSE_MESSAGE_SUFFIX
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
@@ -63,6 +67,8 @@ static rosidl_service_type_support_t @(service.namespaced_type.name)__handle = {
   rosidl_typesupport_fastrtps_c__identifier,
   &@(service.namespaced_type.name)__callbacks,
   get_service_typesupport_handle_function,
+  &_@(service.namespaced_type.name)@(SERVICE_REQUEST_MESSAGE_SUFFIX)__type_support,
+  &_@(service.namespaced_type.name)@(SERVICE_RESPONSE_MESSAGE_SUFFIX)__type_support,
   ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_CREATE_EVENT_MESSAGE_SYMBOL_NAME(
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
@@ -71,8 +77,8 @@ static rosidl_service_type_support_t @(service.namespaced_type.name)__handle = {
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
   ),
-  &_@(service.namespaced_type.name)_Event__type_support,
-  &@(idl_structure_type_to_c_typename(service.namespaced_type))__TYPE_VERSION_HASH,
+  &_@(service.namespaced_type.name)@(SERVICE_EVENT_MESSAGE_SUFFIX)__type_support,
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_HASH_VAR),
 };
 
 const rosidl_service_type_support_t *

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/message_type_support.h
@@ -18,7 +18,6 @@
 #include <fastcdr/Cdr.h>
 
 #include "rosidl_runtime_c/message_type_support_struct.h"
-#include "rosidl_runtime_c/type_hash.h"
 
 /// Feature define to allow API version detection
 #define ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
@@ -38,9 +37,6 @@ typedef struct message_type_support_callbacks_t
 
   /// The typename of this message.
   const char * message_name_;
-
-  /// The hash of the description of the type of this message.
-  const rosidl_type_hash_t type_hash_;
 
   /// Callback function for message serialization
   /**

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/service_type_support.h
@@ -28,8 +28,6 @@ typedef struct service_type_support_callbacks_t
   const char * service_namespace_;
   /// The typename of this service.
   const char * service_name_;
-  /// The hash of the description of the type of this service.
-  const rosidl_type_hash_t type_hash_;
   /// Pointer to the request message typesupport members.
   const rosidl_message_type_support_t * request_members_;
   /// Pointer to the response message typesupport members.

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -1,5 +1,6 @@
 @# Included from rosidl_typesupport_fastrtps_cpp/resource/idl__type_support.cpp.em
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractSequence
@@ -495,7 +496,6 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
 static message_type_support_callbacks_t _@(message.structure.namespaced_type.name)__callbacks = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(message.structure.namespaced_type.name)",
-  @('::'.join(message.structure.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
   _@(message.structure.namespaced_type.name)__cdr_serialize,
   _@(message.structure.namespaced_type.name)__cdr_deserialize,
   _@(message.structure.namespaced_type.name)__get_serialized_size,
@@ -506,6 +506,7 @@ static rosidl_message_type_support_t _@(message.structure.namespaced_type.name)_
   rosidl_typesupport_fastrtps_cpp::typesupport_identifier,
   &_@(message.structure.namespaced_type.name)__callbacks,
   get_message_typesupport_handle_function,
+  &@('::'.join(message.structure.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
 };
 
 }  // namespace typesupport_fastrtps_cpp

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_fastrtps_cpp/resource/idl__type_support.cpp.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractSequence
@@ -506,7 +507,7 @@ static rosidl_message_type_support_t _@(message.structure.namespaced_type.name)_
   rosidl_typesupport_fastrtps_cpp::typesupport_identifier,
   &_@(message.structure.namespaced_type.name)__callbacks,
   get_message_typesupport_handle_function,
-  &@('::'.join(message.structure.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
+  &@('::'.join(message.structure.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
 };
 
 }  // namespace typesupport_fastrtps_cpp

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -76,9 +76,9 @@ static const rosidl_service_type_support_t _@(service.namespaced_type.name)__han
   get_service_typesupport_handle_function,
   ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_REQUEST_MESSAGE_SUFFIX)>(),
   ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_RESPONSE_MESSAGE_SUFFIX)>(),
+  ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_EVENT_MESSAGE_SUFFIX)>(),
   &::rosidl_typesupport_cpp::service_create_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
-  ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_EVENT_MESSAGE_SUFFIX)>(),
   &@('::'.join(service.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
 };
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -59,7 +59,6 @@ namespace typesupport_fastrtps_cpp
 static service_type_support_callbacks_t _@(service.namespaced_type.name)__callbacks = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
   "@(service.namespaced_type.name)",
-  @('::'.join(service.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name + SERVICE_REQUEST_MESSAGE_SUFFIX))(),
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name + SERVICE_RESPONSE_MESSAGE_SUFFIX))(),
 };
@@ -76,6 +75,7 @@ static const rosidl_service_type_support_t _@(service.namespaced_type.name)__han
   &::rosidl_typesupport_cpp::service_create_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))_Event>(),
+  &@('::'.join(service.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
 };
 
 #ifdef __cplusplus

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -1,8 +1,10 @@
 @# Included from rosidl_typesupport_fastrtps_cpp/resource/idl__type_support.cpp.em
 @{
-from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
+from rosidl_generator_type_description import TYPE_HASH_VAR
+from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_RESPONSE_MESSAGE_SUFFIX
+from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -72,10 +74,12 @@ static const rosidl_service_type_support_t _@(service.namespaced_type.name)__han
   rosidl_typesupport_fastrtps_cpp::typesupport_identifier,
   &_@(service.namespaced_type.name)__callbacks,
   get_service_typesupport_handle_function,
+  ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_REQUEST_MESSAGE_SUFFIX)>(),
+  ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_RESPONSE_MESSAGE_SUFFIX)>(),
   &::rosidl_typesupport_cpp::service_create_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
-  ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))_Event>(),
-  &@('::'.join(service.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
+  ::rosidl_typesupport_fastrtps_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_EVENT_MESSAGE_SUFFIX)>(),
+  &@('::'.join(service.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Depends on ros2/rosidl#729 (coupled - must be merged together)
Part of ros2/ros2#1159

1. Fill out new type_hash and message_type_support fields on generated `rosidl_message_type_support_t` and `rosidl_service_type_support_t` structs.
2. Back out addition of the type hash to the typesupport-implementation data bundles
