### PR TITLE
Avoid redundant declarations in generated code for services and actions

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -129,7 +129,7 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 
 # Set compiler flags
 if(NOT WIN32)
-  set(_target_compile_flags -Wall -Wextra -Wpedantic)
+  set(_target_compile_flags -Wall -Wextra -Wpedantic -Wredundant-decls)
 else()
   set(_target_compile_flags /W4)
 endif()

--- a/rosidl_typesupport_fastrtps_cpp/resource/idl__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/idl__type_support.cpp.em
@@ -23,6 +23,7 @@ include_base = '/'.join(include_parts)
 
 @{
 include_directives = set()
+forward_declared_types = set()
 
 #######################################################################
 # Handle message
@@ -32,7 +33,8 @@ for message in content.get_elements_of_type(Message):
     TEMPLATE(
         'msg__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, message=message,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
 
 #######################################################################
 # Handle service
@@ -42,7 +44,8 @@ for service in content.get_elements_of_type(Service):
     TEMPLATE(
         'srv__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, service=service,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
 
 #######################################################################
 # Handle action
@@ -52,25 +55,31 @@ for action in content.get_elements_of_type(Action):
     TEMPLATE(
         'msg__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, message=action.goal,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
     TEMPLATE(
         'msg__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, message=action.result,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
     TEMPLATE(
         'msg__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, message=action.feedback,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
     TEMPLATE(
         'srv__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, service=action.send_goal_service,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
     TEMPLATE(
         'srv__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, service=action.get_result_service,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
     TEMPLATE(
         'msg__type_support.cpp.em',
         package_name=package_name, interface_path=interface_path, message=action.feedback_message,
-        include_directives=include_directives)
+        include_directives=include_directives,
+        forward_declared_types=forward_declared_types)
 }@

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -48,10 +48,14 @@ if isinstance(type_, AbstractNestedType):
     type_ = type_.value_type
 }@
 @[  if isinstance(type_, NamespacedType)]@
-@[    for ns in type_.namespaces]@
+@[    if type_.namespaced_name() in forward_declared_types]@
+// functions for @('::'.join(type_.namespaced_name())) already declared above
+@[    else]@
+@{forward_declared_types.add(type_.namespaced_name())}@
+@[      for ns in type_.namespaces]@
 namespace @(ns)
 {
-@[    end for]@
+@[      end for]@
 namespace typesupport_fastrtps_cpp
 {
 bool cdr_serialize(
@@ -69,9 +73,10 @@ max_serialized_size_@(type_.name)(
   bool & is_plain,
   size_t current_alignment);
 }  // namespace typesupport_fastrtps_cpp
-@[    for ns in reversed(type_.namespaces)]@
+@[      for ns in reversed(type_.namespaces)]@
 }  // namespace @(ns)
-@[    end for]@
+@[      end for]@
+@[    end if]@
 
 @[  end if]@
 @[end for]@
@@ -82,6 +87,7 @@ namespace @(ns)
 {
 @[  end for]@
 
+@{forward_declared_types.add(message.structure.namespaced_type.namespaced_name())}@
 namespace typesupport_fastrtps_cpp
 {
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -17,21 +17,24 @@ include_base = '/'.join(include_parts)
 TEMPLATE(
     'msg__type_support.cpp.em',
     package_name=package_name, interface_path=interface_path, message=service.request_message,
-    include_directives=include_directives)
+    include_directives=include_directives,
+    forward_declared_types=forward_declared_types)
 }@
 
 @{
 TEMPLATE(
     'msg__type_support.cpp.em',
     package_name=package_name, interface_path=interface_path, message=service.response_message,
-    include_directives=include_directives)
+    include_directives=include_directives,
+    forward_declared_types=forward_declared_types)
 }@
 
 @{
 TEMPLATE(
     'msg__type_support.cpp.em',
     package_name=package_name, interface_path=interface_path, message=service.event_message,
-    include_directives=include_directives)
+    include_directives=include_directives,
+    forward_declared_types=forward_declared_types)
 }@
 
 @{


### PR DESCRIPTION
Fixes https://github.com/ros2/rosidl_typesupport_fastrtps/issues/28

The typesupport code generation forward-declares used functions for the types of message member variables. However, for Services and Actions, these types' functions are already defined in the same source file, so the forward-declaration is redundant and raises a warning if `-Wredundant-decls` is enabled.

This patch fixes the redundant declarations, and adds the `-Wredundant-decls` compiler flag to catch it in the future