### PR TITLE
PR 104 (backport 102->humble) Resolve merge conflict

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/srv__type_support.cpp.em
@@ -23,17 +23,6 @@ TEMPLATE(
 }@
 
 @{
-<<<<<<< HEAD
-=======
-TEMPLATE(
-    'msg__type_support.cpp.em',
-    package_name=package_name, interface_path=interface_path, message=service.event_message,
-    include_directives=include_directives,
-    forward_declared_types=forward_declared_types)
-}@
-
-@{
->>>>>>> 9c09ae8 (Avoid redundant declarations in generated code for services and actions (#102))
 header_files = [
     'rmw/error_handling.h',
     'rosidl_typesupport_fastrtps_cpp/identifier.hpp',


### PR DESCRIPTION
Service's Event message doesn't exist in Humble, so we don't need this block

Merges into https://github.com/ros2/rosidl_typesupport_fastrtps/pull/104