### PR TITLE
Account for alignment on `is_plain` calculations

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -625,8 +625,8 @@ if isinstance(type_, AbstractNestedType):
     DataType * data;
     is_plain =
       (
-        offsetof(DataType, @(last_member_name_) ) +
-        sizeof(decltype(data->@(last_member_name_) ) )
+      offsetof(DataType, @(last_member_name_)) +
+      sizeof(decltype(data->@(last_member_name_)))
       ) == ret_val;
   }
 

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -530,6 +530,8 @@ size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.pare
 
   const size_t padding = 4;
   const size_t wchar_size = 4;
+  size_t last_member_size = 0;
+  (void)last_member_size;
   (void)padding;
   (void)wchar_size;
 
@@ -587,27 +589,36 @@ if isinstance(type_, AbstractNestedType):
     }
 @[  elif isinstance(type_, BasicType)]@
 @[    if type_.typename in ('boolean', 'octet', 'char', 'uint8', 'int8')]@
+    last_member_size = array_size * sizeof(uint8_t);
     current_alignment += array_size * sizeof(uint8_t);
 @[    elif type_.typename in ('wchar', 'int16', 'uint16')]@
+    last_member_size = array_size * sizeof(uint16_t);
     current_alignment += array_size * sizeof(uint16_t) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint16_t));
 @[    elif type_.typename in ('int32', 'uint32', 'float')]@
+    last_member_size = array_size * sizeof(uint32_t);
     current_alignment += array_size * sizeof(uint32_t) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint32_t));
 @[    elif type_.typename in ('int64', 'uint64', 'double')]@
+    last_member_size = array_size * sizeof(uint64_t);
     current_alignment += array_size * sizeof(uint64_t) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint64_t));
 @[    elif type_.typename == 'long double']@
+    last_member_size = array_size * sizeof(long double);
     current_alignment += array_size * sizeof(long double) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(long double));
 @[    end if]@
 @[  else]
+    last_member_size = 0;
     for (size_t index = 0; index < array_size; ++index) {
       bool inner_full_bounded;
       bool inner_is_plain;
-      current_alignment +=
+      size_t inner_size;
+      inner_size = 
         max_serialized_size_@('__'.join(type_.namespaced_name()))(
         inner_full_bounded, inner_is_plain, current_alignment);
+      last_member_size += inner_size;
+      current_alignment += inner_size;
       full_bounded &= inner_full_bounded;
       is_plain &= inner_is_plain;
     }
@@ -626,7 +637,7 @@ if isinstance(type_, AbstractNestedType):
     is_plain =
       (
       offsetof(DataType, @(last_member_name_)) +
-      sizeof(decltype(data->@(last_member_name_)))
+      last_member_size
       ) == ret_val;
   }
 

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -536,7 +536,13 @@ size_t max_serialized_size_@('__'.join([package_name] + list(interface_path.pare
   full_bounded = true;
   is_plain = true;
 
+@{
+last_member_name_ = None
+}@
 @[for member in message.structure.members]@
+@{
+last_member_name_ = member.name
+}@
   // member: @(member.name)
   {
 @[  if isinstance(member.type, AbstractNestedType)]@
@@ -609,7 +615,23 @@ if isinstance(type_, AbstractNestedType):
   }
 @[end for]@
 
-  return current_alignment - initial_alignment;
+  size_t ret_val = current_alignment - initial_alignment;
+@[if last_member_name_ is not None]@
+  if (is_plain) {
+    // All members are plain, and type is not empty.
+    // We still need to check that the in-memory alignment
+    // is the same as the CDR mandated alignment.
+    using DataType = @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]));
+    DataType * data;
+    is_plain =
+      (
+        offsetof(DataType, @(last_member_name_) ) +
+        sizeof(decltype(data->@(last_member_name_) ) )
+      ) == ret_val;
+  }
+
+@[end if]@
+  return ret_val;
 }
 
 static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(char & bounds_info)

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -614,7 +614,7 @@ if isinstance(type_, AbstractNestedType):
       bool inner_full_bounded;
       bool inner_is_plain;
       size_t inner_size;
-      inner_size = 
+      inner_size =
         max_serialized_size_@('__'.join(type_.namespaced_name()))(
         inner_full_bounded, inner_is_plain, current_alignment);
       last_member_size += inner_size;
@@ -633,7 +633,6 @@ if isinstance(type_, AbstractNestedType):
     // We still need to check that the in-memory alignment
     // is the same as the CDR mandated alignment.
     using DataType = @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]));
-    DataType * data;
     is_plain =
       (
       offsetof(DataType, @(last_member_name_)) +

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -479,7 +479,6 @@ if isinstance(type_, AbstractNestedType):
     // We still need to check that the in-memory alignment
     // is the same as the CDR mandated alignment.
     using DataType = @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]));
-    DataType * data;
     is_plain =
       (
       offsetof(DataType, @(last_member_name_)) +

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -376,6 +376,8 @@ max_serialized_size_@(message.structure.namespaced_type.name)(
 
   const size_t padding = 4;
   const size_t wchar_size = 4;
+  size_t last_member_size = 0;
+  (void)last_member_size;
   (void)padding;
   (void)wchar_size;
 
@@ -434,27 +436,35 @@ if isinstance(type_, AbstractNestedType):
     }
 @[  elif isinstance(type_, BasicType)]@
 @[    if type_.typename in ('boolean', 'octet', 'char', 'uint8', 'int8')]@
+    last_member_size = array_size * sizeof(uint8_t);
     current_alignment += array_size * sizeof(uint8_t);
 @[    elif type_.typename in ('wchar', 'int16', 'uint16')]@
+    last_member_size = array_size * sizeof(uint16_t);
     current_alignment += array_size * sizeof(uint16_t) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint16_t));
 @[    elif type_.typename in ('int32', 'uint32', 'float')]@
+    last_member_size = array_size * sizeof(uint32_t);
     current_alignment += array_size * sizeof(uint32_t) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint32_t));
 @[    elif type_.typename in ('int64', 'uint64', 'double')]@
+    last_member_size = array_size * sizeof(uint64_t);
     current_alignment += array_size * sizeof(uint64_t) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint64_t));
 @[    elif type_.typename == 'long double']@
+    last_member_size = array_size * sizeof(long double);
     current_alignment += array_size * sizeof(long double) +
       eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(long double));
 @[    end if]@
 @[  else]
+    last_member_size = 0;
     for (size_t index = 0; index < array_size; ++index) {
       bool inner_full_bounded;
       bool inner_is_plain;
-      current_alignment +=
+      size_t inner_size =
         @('::'.join(type_.namespaces))::typesupport_fastrtps_cpp::max_serialized_size_@(type_.name)(
         inner_full_bounded, inner_is_plain, current_alignment);
+      last_member_size += inner_size;
+      current_alignment += inner_size;
       full_bounded &= inner_full_bounded;
       is_plain &= inner_is_plain;
     }
@@ -473,7 +483,7 @@ if isinstance(type_, AbstractNestedType):
     is_plain =
       (
       offsetof(DataType, @(last_member_name_)) +
-      sizeof(decltype(data->@(last_member_name_)))
+      last_member_size
       ) == ret_val;
   }
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -468,12 +468,12 @@ if isinstance(type_, AbstractNestedType):
     // All members are plain, and type is not empty.
     // We still need to check that the in-memory alignment
     // is the same as the CDR mandated alignment.
-    using DataType = @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]) );
+    using DataType = @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]));
     DataType * data;
     is_plain =
       (
-        offsetof(DataType, @(last_member_name_) ) +
-        sizeof(decltype(data->@(last_member_name_) ) )
+      offsetof(DataType, @(last_member_name_)) +
+      sizeof(decltype(data->@(last_member_name_)))
       ) == ret_val;
   }
 


### PR DESCRIPTION
This shall address https://github.com/ros2/rmw_fastrtps/issues/715 by taking into consideration whether the alignment generated by the compiler is compatible with the one required by the CDR serialization.