### PR TITLE
Improve wide string (de)serialization

### DIFF
--- a/rosidl_typesupport_fastrtps_c/CMakeLists.txt
+++ b/rosidl_typesupport_fastrtps_c/CMakeLists.txt
@@ -35,8 +35,10 @@ endif()
 
 find_package(ament_cmake_python REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
+find_package(fastcdr REQUIRED CONFIG)
 
 ament_export_dependencies(rosidl_runtime_c)
+ament_export_dependencies(fastcdr)
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -49,6 +51,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${PROJECT_NAME} PUBLIC
+  fastcdr
   rosidl_runtime_c::rosidl_runtime_c)
 
 # Export old-style CMake variables

--- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "fastcdr/Cdr.h"
+#include "fastcdr/exceptions/BadParamException.h"
 
 #include "rosidl_runtime_c/u16string.h"
 #include "rosidl_runtime_c/u16string_functions.h"
@@ -58,6 +59,9 @@ inline bool cdr_deserialize(
   for (uint32_t i = 0; i < len; ++i) {
     uint32_t c;
     cdr >> c;
+    if (c > std::numeric_limits<uint_least16_t>::max()) {
+      throw eprosima::fastcdr::exception::BadParamException("Character value exceeds maximum value");
+    }
     u16str.data[i] = static_cast<uint_least16_t>(c);
   }
 

--- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
@@ -1,0 +1,64 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_FASTRTPS_C__SERIALIZATION_HELPERS_HPP_
+#define ROSIDL_TYPESUPPORT_FASTRTPS_C__SERIALIZATION_HELPERS_HPP_
+
+#include <string>
+
+#include "fastcdr/Cdr.h"
+
+#include "rosidl_runtime_c/u16string.h"
+#include "rosidl_runtime_c/u16string_functions.h"
+
+#include "rosidl_typesupport_fastrtps_c/visibility_control.h"
+
+namespace rosidl_typesupport_fastrtps_c
+{
+
+inline void cdr_serialize(
+  eprosima::fastcdr::Cdr & cdr,
+  const rosidl_runtime_c__U16String & u16str)
+{
+  auto len = static_cast<uint32_t>(u16str.size);
+  cdr << len;
+  for (uint32_t i = 0; i < len; ++i) {
+    uint32_t c = static_cast<uint32_t>(u16str.data[i]);
+    cdr << c;
+  }
+}
+
+inline bool cdr_deserialize(
+  eprosima::fastcdr::Cdr & cdr,
+  rosidl_runtime_c__U16String & u16str)
+{
+  uint32_t len;
+  cdr >> len;
+  bool succeeded = rosidl_runtime_c__U16String__resize(&u16str, len);
+  if (!succeeded) {
+    return false;
+  }
+
+  for (uint32_t i = 0; i < len; ++i) {
+    uint32_t c;
+    cdr >> c;
+    u16str.data[i] = static_cast<char16_t>(c);
+  }
+
+  return true;
+}
+
+}  // namespace rosidl_typesupport_fastrtps_c
+
+#endif  // ROSIDL_TYPESUPPORT_FASTRTPS_C__SERIALIZATION_HELPERS_HPP_

--- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
@@ -40,6 +40,10 @@ inline void cdr_serialize(
   auto len = static_cast<uint32_t>(u16str.size);
   cdr << len;
   for (uint32_t i = 0; i < len; ++i) {
+    // We are serializing a uint32_t for interoperability with other DDS-based implementations.
+    // We might change this to a uint16_t in the future if we don't mind breaking backward
+    // compatibility and we make the change for all the supported DDS implementations at the same
+    // time.
     uint32_t c = static_cast<uint32_t>(u16str.data[i]);
     cdr << c;
   }
@@ -57,6 +61,9 @@ inline bool cdr_deserialize(
   }
 
   for (uint32_t i = 0; i < len; ++i) {
+    // We are serializing a uint32_t for interoperability with other DDS-based implementations.
+    // If we change this to a uint16_t in the future, we could remove the check below, since all
+    // serialized values would fit in the destination type.
     uint32_t c;
     cdr >> c;
     if (c > std::numeric_limits<uint_least16_t>::max()) {

--- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
@@ -15,6 +15,8 @@
 #ifndef ROSIDL_TYPESUPPORT_FASTRTPS_C__SERIALIZATION_HELPERS_HPP_
 #define ROSIDL_TYPESUPPORT_FASTRTPS_C__SERIALIZATION_HELPERS_HPP_
 
+#include <limits>
+#include <stdexcept>
 #include <string>
 
 #include "fastcdr/Cdr.h"
@@ -31,6 +33,9 @@ inline void cdr_serialize(
   eprosima::fastcdr::Cdr & cdr,
   const rosidl_runtime_c__U16String & u16str)
 {
+  if (u16str.size > std::numeric_limits<uint32_t>::max()) {
+    throw std::overflow_error("String length exceeds does not fit in CDR serialization format");
+  }
   auto len = static_cast<uint32_t>(u16str.size);
   cdr << len;
   for (uint32_t i = 0; i < len; ++i) {

--- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
@@ -67,7 +67,8 @@ inline bool cdr_deserialize(
     uint32_t c;
     cdr >> c;
     if (c > std::numeric_limits<uint_least16_t>::max()) {
-      throw eprosima::fastcdr::exception::BadParamException("Character value exceeds maximum value");
+      throw eprosima::fastcdr::exception::BadParamException(
+              "Character value exceeds maximum value");
     }
     u16str.data[i] = static_cast<uint_least16_t>(c);
   }

--- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/serialization_helpers.hpp
@@ -58,7 +58,7 @@ inline bool cdr_deserialize(
   for (uint32_t i = 0; i < len; ++i) {
     uint32_t c;
     cdr >> c;
-    u16str.data[i] = static_cast<char16_t>(c);
+    u16str.data[i] = static_cast<uint_least16_t>(c);
   }
 
   return true;

--- a/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/wstring_conversion.hpp
+++ b/rosidl_typesupport_fastrtps_c/include/rosidl_typesupport_fastrtps_c/wstring_conversion.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include "rcutils/macros.h"
 #include "rosidl_runtime_c/u16string.h"
 #include "rosidl_typesupport_fastrtps_c/visibility_control.h"
 
@@ -29,6 +30,7 @@ namespace rosidl_typesupport_fastrtps_c
  * \param[in,out] wstr The std::wstring to copy to.
  */
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC
+  RCUTILS_DEPRECATED_WITH_MSG("not used by core packages")
 void u16string_to_wstring(
   const rosidl_runtime_c__U16String & u16str, std::wstring & wstr);
 
@@ -39,6 +41,7 @@ void u16string_to_wstring(
  * \return true if resizing u16str and assignment succeeded, otherwise false.
  */
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC
+  RCUTILS_DEPRECATED_WITH_MSG("not used by core packages")
 bool wstring_to_u16string(
   const std::wstring & wstr, rosidl_runtime_c__U16String & u16str);
 

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -32,6 +32,7 @@ header_files = [
     'string',
     # Provides the rosidl_typesupport_fastrtps_c__identifier symbol declaration.
     'rosidl_typesupport_fastrtps_c/identifier.h',
+    'rosidl_typesupport_fastrtps_c/serialization_helpers.hpp',
     'rosidl_typesupport_fastrtps_c/wstring_conversion.hpp',
     # Provides the definition of the message_type_support_callbacks_t struct.
     'rosidl_typesupport_fastrtps_cpp/message_type_support.h',

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -216,7 +216,6 @@ if isinstance(type_, AbstractNestedType):
       cdr << str->data;
     }
 @[    elif isinstance(member.type.value_type, AbstractWString)]@
-    std::wstring wstr;
     for (size_t i = 0; i < size; ++i) {
       const rosidl_runtime_c__U16String * str = &array_ptr[i];
       if (str->capacity == 0 || str->capacity <= str->size) {
@@ -227,8 +226,7 @@ if isinstance(type_, AbstractNestedType):
         fprintf(stderr, "string not null-terminated\n");
         return false;
       }
-      rosidl_typesupport_fastrtps_c::u16string_to_wstring(*str, wstr);
-      cdr << wstr;
+      rosidl_typesupport_fastrtps_c::cdr_serialize(cdr, *str);
     }
 @[    elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
     for (size_t i = 0; i < size; ++i) {
@@ -261,9 +259,7 @@ if isinstance(type_, AbstractNestedType):
     }
     cdr << str->data;
 @[  elif isinstance(member.type, AbstractWString)]@
-    std::wstring wstr;
-    rosidl_typesupport_fastrtps_c::u16string_to_wstring(ros_message->@(member.name), wstr);
-    cdr << wstr;
+    rosidl_typesupport_fastrtps_c::cdr_serialize(cdr, ros_message->@(member.name));
 @[  elif isinstance(member.type, BasicType) and member.type.typename == 'boolean']@
     cdr << (ros_message->@(member.name) ? true : false);
 @[  elif isinstance(member.type, BasicType) and member.type.typename == 'wchar']@
@@ -363,8 +359,7 @@ else:
       if (!ros_i.data) {
         rosidl_runtime_c__U16String__init(&ros_i);
       }
-      cdr >> wstr;
-      bool succeeded = rosidl_typesupport_fastrtps_c::wstring_to_u16string(wstr, ros_i);
+      bool succeeded = rosidl_typesupport_fastrtps_c::cdr_deserialize(cdr, ros_i);
       if (!succeeded) {
         fprintf(stderr, "failed to create wstring from u16string\n");
         rosidl_runtime_c__U16String__fini(&ros_i);
@@ -411,9 +406,7 @@ else:
     if (!ros_message->@(member.name).data) {
       rosidl_runtime_c__U16String__init(&ros_message->@(member.name));
     }
-    std::wstring wstr;
-    cdr >> wstr;
-    bool succeeded = rosidl_typesupport_fastrtps_c::wstring_to_u16string(wstr, ros_message->@(member.name));
+    bool succeeded = rosidl_typesupport_fastrtps_c::cdr_deserialize(cdr, ros_message->@(member.name));
     if (!succeeded) {
       fprintf(stderr, "failed to create wstring from u16string\n");
       rosidl_runtime_c__U16String__fini(&ros_message->@(member.name));

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
@@ -55,7 +55,7 @@ inline bool cdr_deserialize(
   for (uint32_t i = 0; i < len; ++i) {
     uint32_t c;
     cdr >> c;
-    u16str[i] = static_cast<char16_t>(c);
+    u16str[i] = static_cast<std::u16string::value_type>(c);
   }
 
   return true;

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
@@ -37,6 +37,10 @@ inline void cdr_serialize(
   auto len = static_cast<uint32_t>(u16str.size());
   cdr << len;
   for (uint32_t i = 0; i < len; ++i) {
+    // We are serializing a uint32_t for interoperability with other DDS-based implementations.
+    // We might change this to a uint16_t in the future if we don't mind breaking backward
+    // compatibility and we make the change for all the supported DDS implementations at the same
+    // time.
     uint32_t c = static_cast<uint32_t>(u16str[i]);
     cdr << c;
   }
@@ -54,6 +58,9 @@ inline bool cdr_deserialize(
     return false;
   }
   for (uint32_t i = 0; i < len; ++i) {
+    // We are serializing a uint32_t for interoperability with other DDS-based implementations.
+    // If we change this to a uint16_t in the future, we could remove the check below, since all
+    // serialized values would fit in the destination type.
     uint32_t c;
     cdr >> c;
     if (c > std::numeric_limits<std::u16string::value_type>::max()) {

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
@@ -64,7 +64,8 @@ inline bool cdr_deserialize(
     uint32_t c;
     cdr >> c;
     if (c > std::numeric_limits<std::u16string::value_type>::max()) {
-      throw eprosima::fastcdr::exception::BadParamException("Character value exceeds maximum value");
+      throw eprosima::fastcdr::exception::BadParamException(
+              "Character value exceeds maximum value");
     }
     u16str[i] = static_cast<std::u16string::value_type>(c);
   }

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
@@ -18,6 +18,7 @@
 #include <rosidl_typesupport_fastrtps_cpp/visibility_control.h>
 
 #include <fastcdr/Cdr.h>
+#include <fastcdr/exceptions/BadParamException.h>
 
 #include <limits>
 #include <stdexcept>
@@ -55,6 +56,9 @@ inline bool cdr_deserialize(
   for (uint32_t i = 0; i < len; ++i) {
     uint32_t c;
     cdr >> c;
+    if (c > std::numeric_limits<std::u16string::value_type>::max()) {
+      throw eprosima::fastcdr::exception::BadParamException("Character value exceeds maximum value");
+    }
     u16str[i] = static_cast<std::u16string::value_type>(c);
   }
 

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
@@ -19,6 +19,8 @@
 
 #include <fastcdr/Cdr.h>
 
+#include <limits>
+#include <stdexcept>
 #include <string>
 
 namespace rosidl_typesupport_fastrtps_cpp
@@ -28,6 +30,9 @@ inline void cdr_serialize(
   eprosima::fastcdr::Cdr & cdr,
   const std::u16string & u16str)
 {
+  if (u16str.size() > std::numeric_limits<uint32_t>::max()) {
+    throw std::overflow_error("String length exceeds does not fit in CDR serialization format");
+  }
   auto len = static_cast<uint32_t>(u16str.size());
   cdr << len;
   for (uint32_t i = 0; i < len; ++i) {

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp
@@ -1,0 +1,61 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_FASTRTPS_CPP__SERIALIZATION_HELPERS_HPP_
+#define ROSIDL_TYPESUPPORT_FASTRTPS_CPP__SERIALIZATION_HELPERS_HPP_
+
+#include <rosidl_typesupport_fastrtps_cpp/visibility_control.h>
+
+#include <fastcdr/Cdr.h>
+
+#include <string>
+
+namespace rosidl_typesupport_fastrtps_cpp
+{
+
+inline void cdr_serialize(
+  eprosima::fastcdr::Cdr & cdr,
+  const std::u16string & u16str)
+{
+  auto len = static_cast<uint32_t>(u16str.size());
+  cdr << len;
+  for (uint32_t i = 0; i < len; ++i) {
+    uint32_t c = static_cast<uint32_t>(u16str[i]);
+    cdr << c;
+  }
+}
+
+inline bool cdr_deserialize(
+  eprosima::fastcdr::Cdr & cdr,
+  std::u16string & u16str)
+{
+  uint32_t len;
+  cdr >> len;
+  try {
+    u16str.resize(len);
+  } catch (...) {
+    return false;
+  }
+  for (uint32_t i = 0; i < len; ++i) {
+    uint32_t c;
+    cdr >> c;
+    u16str[i] = static_cast<char16_t>(c);
+  }
+
+  return true;
+}
+
+}  // namespace rosidl_typesupport_fastrtps_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_FASTRTPS_CPP__SERIALIZATION_HELPERS_HPP_

--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp
@@ -19,6 +19,8 @@
 
 #include <string>
 
+#include "rcutils/macros.h"
+
 namespace rosidl_typesupport_fastrtps_cpp
 {
 
@@ -28,6 +30,7 @@ namespace rosidl_typesupport_fastrtps_cpp
  * \param[in,out] wstr The std::wstring to copy to.
  */
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC
+  RCUTILS_DEPRECATED_WITH_MSG("not used by core packages")
 void u16string_to_wstring(const std::u16string & u16str, std::wstring & wstr);
 
 /// Convert a std::wstring into a std::u16string.
@@ -37,6 +40,7 @@ void u16string_to_wstring(const std::u16string & u16str, std::wstring & wstr);
  * \return true if resizing u16str and assignment succeeded, otherwise false.
  */
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC
+  RCUTILS_DEPRECATED_WITH_MSG("not used by core packages")
 bool wstring_to_u16string(const std::wstring & wstr, std::u16string & u16str);
 
 }  // namespace rosidl_typesupport_fastrtps_cpp

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -106,17 +106,13 @@ cdr_serialize(
 @[      if not isinstance(member.type.value_type, (NamespacedType, AbstractWString))]@
     cdr << ros_message.@(member.name);
 @[      else]@
-@[        if isinstance(member.type.value_type, AbstractWString)]@
-    std::wstring wstr;
-@[        end if]@
     for (size_t i = 0; i < @(member.type.size); i++) {
 @[        if isinstance(member.type.value_type, NamespacedType)]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_serialize(
         ros_message.@(member.name)[i],
         cdr);
 @[        else]@
-      rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(ros_message.@(member.name)[i], wstr);
-      cdr << wstr;
+      rosidl_typesupport_fastrtps_cpp::cdr_serialize(cdr, ros_message.@(member.name)[i]);
 @[        end if]@
     }
 @[      end if]@
@@ -138,17 +134,13 @@ cdr_serialize(
       cdr.serializeArray(&(ros_message.@(member.name)[0]), size);
     }
 @[        else]@
-@[            if isinstance(member.type.value_type, AbstractWString)]@
-    std::wstring wstr;
-@[            end if]@
     for (size_t i = 0; i < size; i++) {
 @[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       cdr << (ros_message.@(member.name)[i] ? true : false);
 @[            elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
       cdr << static_cast<wchar_t>(ros_message.@(member.name)[i]);
 @[            elif isinstance(member.type.value_type, AbstractWString)]@
-      rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(ros_message.@(member.name)[i], wstr);
-      cdr << wstr;
+      rosidl_typesupport_fastrtps_cpp::cdr_serialize(cdr, ros_message.@(member.name)[i]);
 @[            elif not isinstance(member.type.value_type, NamespacedType)]@
       cdr << ros_message.@(member.name)[i];
 @[            else]@
@@ -167,9 +159,7 @@ cdr_serialize(
   cdr << static_cast<wchar_t>(ros_message.@(member.name));
 @[  elif isinstance(member.type, AbstractWString)]@
   {
-    std::wstring wstr;
-    rosidl_typesupport_fastrtps_cpp::u16string_to_wstring(ros_message.@(member.name), wstr);
-    cdr << wstr;
+    rosidl_typesupport_fastrtps_cpp::cdr_serialize(cdr, ros_message.@(member.name));
   }
 @[  elif not isinstance(member.type, NamespacedType)]@
   cdr << ros_message.@(member.name);
@@ -196,19 +186,15 @@ cdr_deserialize(
 @[      if not isinstance(member.type.value_type, (NamespacedType, AbstractWString))]@
     cdr >> ros_message.@(member.name);
 @[      else]@
-@[        if isinstance(member.type.value_type, AbstractWString)]@
-    std::wstring wstr;
-@[        end if]@
     for (size_t i = 0; i < @(member.type.size); i++) {
 @[        if isinstance(member.type.value_type, NamespacedType)]@
       @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
         cdr,
         ros_message.@(member.name)[i]);
 @[        else]@
-      cdr >> wstr;
-      bool succeeded = rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstr, ros_message.@(member.name)[i]);
+      bool succeeded = rosidl_typesupport_fastrtps_cpp::cdr_deserialize(cdr, ros_message.@(member.name)[i]);
       if (!succeeded) {
-        fprintf(stderr, "failed to create wstring from u16string\n");
+        fprintf(stderr, "failed to deserialize u16string\n");
         return false;
       }
 @[        end if]@
@@ -227,9 +213,6 @@ cdr_deserialize(
       cdr.deserializeArray(&(ros_message.@(member.name)[0]), size);
     }
 @[        else]@
-@[            if isinstance(member.type.value_type, AbstractWString)]@
-    std::wstring wstr;
-@[            end if]@
     for (size_t i = 0; i < size; i++) {
 @[            if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
       uint8_t tmp;
@@ -240,10 +223,9 @@ cdr_deserialize(
       cdr >> tmp;
       ros_message.@(member.name)[i] = static_cast<char16_t>(tmp);
 @[            elif isinstance(member.type.value_type, AbstractWString)]@
-      cdr >> wstr;
-      bool succeeded = rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstr, ros_message.@(member.name)[i]);
+      bool succeeded = rosidl_typesupport_fastrtps_cpp::cdr_deserialize(cdr, ros_message.@(member.name)[i]);
       if (!succeeded) {
-        fprintf(stderr, "failed to create wstring from u16string\n");
+        fprintf(stderr, "failed to deserialize u16string\n");
         return false;
       }
 @[            elif not isinstance(member.type.value_type, NamespacedType)]@
@@ -271,11 +253,9 @@ cdr_deserialize(
   }
 @[  elif isinstance(member.type, AbstractWString)]@
   {
-    std::wstring wstr;
-    cdr >> wstr;
-    bool succeeded = rosidl_typesupport_fastrtps_cpp::wstring_to_u16string(wstr, ros_message.@(member.name));
+    bool succeeded = rosidl_typesupport_fastrtps_cpp::cdr_deserialize(cdr, ros_message.@(member.name));
     if (!succeeded) {
-      fprintf(stderr, "failed to create wstring from u16string\n");
+      fprintf(stderr, "failed to deserialize u16string\n");
       return false;
     }
   }

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -21,6 +21,7 @@ header_files = [
     'rosidl_typesupport_fastrtps_cpp/identifier.hpp',
     'rosidl_typesupport_fastrtps_cpp/message_type_support.h',
     'rosidl_typesupport_fastrtps_cpp/message_type_support_decl.hpp',
+    'rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp',
     'rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp',
     'fastcdr/Cdr.h',
 ]


### PR DESCRIPTION
This PR changes (de)serialization of wide strings so they don't perform `u16string` <-> `wstring` conversions