### PR TITLE
add mingw support (check MSVC instead of WIN32 in cmake)

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -136,7 +136,7 @@ target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBL
   rosidl_typesupport_fastrtps_cpp::rosidl_typesupport_fastrtps_cpp
   rosidl_typesupport_fastrtps_c::rosidl_typesupport_fastrtps_c)
 
-if(NOT WIN32)
+if(NOT MSVC AND NOT MSVC_IDE)
   set(_target_compile_flags -Wall -Wextra -Wpedantic)
 else()
   set(_target_compile_flags /W4)

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -144,7 +144,7 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     CXX_STANDARD 17)
 
 # Set compiler flags
-if(NOT WIN32)
+if(NOT MSVC AND NOT MSVC_IDE)
   set(_target_compile_flags -Wall -Wextra -Wpedantic -Wredundant-decls)
 else()
   set(_target_compile_flags /W4)


### PR DESCRIPTION
Change the cmake compiler flag checking condition from system (`WIN32`) to compiler (`MSVC` `MSVC_IDE`), 

as a result, this project can also support `mingw` environment. 