### PR TITLE
Check remaining size before resizing sequences

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -356,6 +356,16 @@ else:
     uint32_t cdrSize;
     cdr >> cdrSize;
     size_t size = static_cast<size_t>(cdrSize);
+
+    // Check there are at least 'size' remaining bytes in the CDR stream before resizing
+    auto old_state = cdr.get_state();
+    bool correct_size = cdr.jump(size);
+    cdr.set_state(old_state);
+    if (!correct_size) {
+      fprintf(stderr, "sequence size exceeds remaining buffer\n");
+      return false;
+    }
+
     if (ros_message->@(member.name).data) {
       @(array_fini)(&ros_message->@(member.name));
     }

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -306,7 +306,7 @@ cdr_deserialize(
 
 @[end for]@
   return true;
-}
+}  // NOLINT(readability/fn_size)
 
 @{
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -235,6 +235,16 @@ cdr_deserialize(
     uint32_t cdrSize;
     cdr >> cdrSize;
     size_t size = static_cast<size_t>(cdrSize);
+
+    // Check there are at least 'size' remaining bytes in the CDR stream before resizing
+    auto old_state = cdr.get_state();
+    bool correct_size = cdr.jump(size);
+    cdr.set_state(old_state);
+    if (!correct_size) {
+      fprintf(stderr, "sequence size exceeds remaining buffer\n");
+      return false;
+    }
+
     ros_message.@(member.name).resize(size);
 @[        if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename not in ('boolean', 'wchar')]@
     if (size > 0) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Introducing a fix for ros2/rmw_fastrtps#828 and ros2/rmw_fastrtps#797 (when backported to humble)

The idea is to check the deserialized sequence size against the remaining size in the CDR stream, and fail when insufficient.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

NO
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

When backporting to Iron and earlier distributions, we would need to change calls to `get_state` / `set_state` into `getState` / `setState`