### PR TITLE
Switch ament_index_python and rosidl_cli to exec_depend.

### DIFF
--- a/rosidl_typesupport_fastrtps_c/package.xml
+++ b/rosidl_typesupport_fastrtps_c/package.xml
@@ -36,8 +36,8 @@
   <depend>rosidl_typesupport_fastrtps_cpp</depend>
 
   <!-- Needed for the python library it installs, which is also used to generate interfaces -->
-  <depend>ament_index_python</depend>
-  <depend>rosidl_cli</depend>
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rosidl_cli</exec_depend>
   <exec_depend>rosidl_pycommon</exec_depend>
 
   <!-- Needed for tests in this package -->

--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -36,8 +36,8 @@
   <depend>rosidl_runtime_c</depend>
 
   <!-- Needed for the python library it installs, which is also used to generate interfaces -->
-  <depend>ament_index_python</depend>
-  <depend>rosidl_cli</depend>
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rosidl_cli</exec_depend>
   <exec_depend>rosidl_pycommon</exec_depend>
 
   <!-- Needed for tests in this package -->


### PR DESCRIPTION
## Description

The dependencies on ament_index_python and rosidl_cli should be exec_depend, since they are only needed at runtime.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.