### PR TITLE
Allow deprecating fields of interfaces

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -220,6 +220,10 @@ def generate_member_for_cdr_serialize(member, suffix):
   from rosidl_parser.definition import NamespacedType
   strlist = []
   strlist.append('// Field name: %s' % (member.name))
+
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_PUSH')
+
   strlist.append('{')
 
   type_ = member.type
@@ -301,6 +305,9 @@ def generate_member_for_cdr_serialize(member, suffix):
     strlist.append('    &ros_message->%s, cdr);' % (member.name))
   strlist.append('}')
 
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_POP')
+
   return strlist
 }@
 
@@ -325,6 +332,9 @@ bool cdr_deserialize_@('__'.join([package_name] + list(interface_path.parents[0]
 {
 @[for member in message.structure.members]@
   // Field name: @(member.name)
+@[  if member.has_annotation('deprecated')]@
+  DISABLE_DEPRECATED_PUSH
+@[end if]@
   {
 @{
 type_ = member.type
@@ -460,6 +470,9 @@ else:
     cdr_deserialize_@('__'.join(member.type.namespaced_name()))(cdr, &ros_message->@(member.name));
 @[  end if]@
   }
+@[  if member.has_annotation('deprecated')]@
+  DISABLE_DEPRECATED_POP
+@[end if]@
 
 @[end for]@
   return true;
@@ -485,6 +498,10 @@ def generate_member_for_get_serialized_size(member, suffix):
   from rosidl_parser.definition import NamespacedType
   strlist = []
   strlist.append('// Field name: %s' % (member.name))
+
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_PUSH')
+
   if isinstance(member.type, AbstractNestedType):
     strlist.append('{')
     if isinstance(member.type, Array):
@@ -530,6 +547,10 @@ def generate_member_for_get_serialized_size(member, suffix):
     else:
       strlist.append('current_alignment += get_serialized_size%s_%s(' % (suffix, ('__'.join(member.type.namespaced_name()))))
       strlist.append('  &(ros_message->%s), current_alignment);' % (member.name))
+
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_POP')
+  
   return strlist
 }@
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -122,6 +122,10 @@ def generate_member_for_cdr_serialize(member, suffix):
   from rosidl_parser.definition import NamespacedType
   strlist = []
   strlist.append('// Member: %s' % (member.name))
+
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_PUSH')
+
   if isinstance(member.type, AbstractNestedType):
     strlist.append('{')
     if isinstance(member.type, Array):
@@ -181,6 +185,10 @@ def generate_member_for_cdr_serialize(member, suffix):
     strlist.append('%s::typesupport_fastrtps_cpp::cdr_serialize%s(' % (('::'.join(member.type.namespaces)), suffix))
     strlist.append('  ros_message.%s,' % (member.name))
     strlist.append('  cdr);')
+
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_POP')
+
   return strlist
 }@
 
@@ -207,6 +215,9 @@ cdr_deserialize(
 {
 @[for member in message.structure.members]@
   // Member: @(member.name)
+@[  if member.has_annotation('deprecated')]@
+  DISABLE_DEPRECATED_PUSH
+@[  end if]
 @[  if isinstance(member.type, AbstractNestedType)]@
   {
 @[    if isinstance(member.type, Array)]@
@@ -303,6 +314,9 @@ cdr_deserialize(
     cdr, ros_message.@(member.name));
 @[  end if]@
 
+@[  if member.has_annotation('deprecated')]@
+  DISABLE_DEPRECATED_POP
+@[  end if]
 @[end for]@
   return true;
 }  // NOLINT(readability/fn_size)
@@ -326,6 +340,9 @@ def generate_member_for_get_serialized_size(member, suffix):
   from rosidl_parser.definition import NamespacedType
   strlist = []
   strlist.append('// Member: %s' % (member.name))
+
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_PUSH')
 
   if isinstance(member.type, AbstractNestedType):
     strlist.append('{')
@@ -376,6 +393,8 @@ def generate_member_for_get_serialized_size(member, suffix):
       strlist.append('  %s::typesupport_fastrtps_cpp::get_serialized_size%s(' % (('::'.join(member.type.namespaces)), suffix))
       strlist.append('  ros_message.%s, current_alignment);' % (member.name))
 
+  if (member.has_annotation('deprecated')):
+    strlist.append('DISABLE_DEPRECATED_POP')
   return strlist;
 }@
 
@@ -421,7 +440,6 @@ def generate_member_for_max_serialized_size(member, suffix):
   strlist = []
   strlist.append('// Member: %s' % (member.name))
   strlist.append('{')
-
   if isinstance(member.type, AbstractNestedType):
     if isinstance(member.type, Array):
       strlist.append('  size_t array_size = %d;' % (member.type.size))

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -123,7 +123,8 @@ def generate_member_for_cdr_serialize(member, suffix):
   strlist = []
   strlist.append('// Member: %s' % (member.name))
 
-  if (member.has_annotation('deprecated')):
+  if member.has_annotation('deprecated'):
+    strlist.append('// *INDENT-OFF*')
     strlist.append('DISABLE_DEPRECATED_PUSH')
 
   if isinstance(member.type, AbstractNestedType):
@@ -186,8 +187,9 @@ def generate_member_for_cdr_serialize(member, suffix):
     strlist.append('  ros_message.%s,' % (member.name))
     strlist.append('  cdr);')
 
-  if (member.has_annotation('deprecated')):
+  if member.has_annotation('deprecated'):
     strlist.append('DISABLE_DEPRECATED_POP')
+    strlist.append('// *INDENT-ON*')
 
   return strlist
 }@
@@ -216,6 +218,7 @@ cdr_deserialize(
 @[for member in message.structure.members]@
   // Member: @(member.name)
 @[  if member.has_annotation('deprecated')]@
+  // *INDENT-OFF*
   DISABLE_DEPRECATED_PUSH
 @[  end if]
 @[  if isinstance(member.type, AbstractNestedType)]@
@@ -313,9 +316,9 @@ cdr_deserialize(
   @('::'.join(member.type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
     cdr, ros_message.@(member.name));
 @[  end if]@
-
 @[  if member.has_annotation('deprecated')]@
   DISABLE_DEPRECATED_POP
+  // *INDENT-ON*
 @[  end if]
 @[end for]@
   return true;
@@ -341,7 +344,7 @@ def generate_member_for_get_serialized_size(member, suffix):
   strlist = []
   strlist.append('// Member: %s' % (member.name))
 
-  if (member.has_annotation('deprecated')):
+  if member.has_annotation('deprecated'):
     strlist.append('DISABLE_DEPRECATED_PUSH')
 
   if isinstance(member.type, AbstractNestedType):
@@ -393,8 +396,9 @@ def generate_member_for_get_serialized_size(member, suffix):
       strlist.append('  %s::typesupport_fastrtps_cpp::get_serialized_size%s(' % (('::'.join(member.type.namespaces)), suffix))
       strlist.append('  ros_message.%s, current_alignment);' % (member.name))
 
-  if (member.has_annotation('deprecated')):
+  if member.has_annotation('deprecated'):
     strlist.append('DISABLE_DEPRECATED_POP')
+
   return strlist;
 }@
 


### PR DESCRIPTION
## Description

Proposes adding support for annotatoins with the form  `@deprecated ( text='foo' )`.

For now only supports `.idl` since this shouldn't happen often. This method allows us to add support in the future if we desire.

Fixes https://github.com/ros2/ros2/issues/1679

Note: I can do python also if this methodology is approved.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
