### PR TITLE
Add missing build dependencies for exported dependencies

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/package.xml
+++ b/rosidl_typesupport_fastrtps_cpp/package.xml
@@ -26,6 +26,9 @@
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
 
+  <!-- Needed by this package to export the dependency for downstream targets -->
+  <build_depend>rosidl_runtime_cpp</build_depend>
+
   <!-- Needed by downstream targets to use this package's headers or the headers it generates, but header only so not needed to link against -->
   <build_export_depend>rosidl_runtime_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>


### PR DESCRIPTION
## Description

The call to ament_export_dependencies for this exported build dependency requires that the dependency is `find_package`-able during this package's build. We should declare that dependency explicitly.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

This bug was found as part of the dynamic RPM packaging work, which treats `export_depends` differently from `exec_depends` for the for the first time.