### PR TITLE
Update rosidl typesupport to support rosidl::Buffer in nested uint8[]

### DIFF
--- a/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__rosidl_typesupport_fastrtps_c.h.em
@@ -73,6 +73,9 @@ size_t max_serialized_size_key_@('__'.join([package_name] + list(interface_path.
   size_t current_alignment);
 
 ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
+bool has_buffer_fields_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))();
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
 const rosidl_message_type_support_t *
 ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name])))();
 

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -45,12 +45,14 @@ for member in message.structure.members:
             _seen_nested_type_keys.add(key)
             nested_type_keys.append(key)
 
-has_buffer_field_checks = ['true' if has_direct_buffer_fields else 'false']
-has_buffer_field_checks.extend(
-    'has_buffer_fields_%s()' % '__'.join(nested_key)
-    for nested_key in nested_type_keys
-)
-has_buffer_fields_expression = ' ||\n    '.join(has_buffer_field_checks)
+if has_direct_buffer_fields:
+    has_buffer_fields_expression = 'true'
+else:
+    has_buffer_field_checks = [
+        'has_buffer_fields_%s()' % '__'.join(nested_key)
+        for nested_key in nested_type_keys
+    ]
+    has_buffer_fields_expression = ' ||\n    '.join(has_buffer_field_checks) or 'false'
 
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -673,7 +675,7 @@ def generate_member_for_get_serialized_size(member, suffix):
     strlist.append('    if (buffer != nullptr) {')
     strlist.append('      current_alignment +=')
     strlist.append('        rosidl_typesupport_fastrtps_cpp::get_buffer_serialized_size(')
-    strlist.append('          *buffer, current_alignment);')
+    strlist.append('        *buffer, current_alignment);')
     strlist.append('    }')
     strlist.append('  } else {')
     strlist.append('    size_t array_size = ros_message->%s.size;' % member.name)
@@ -1008,7 +1010,7 @@ static size_t _@(message.structure.namespaced_type.name)__get_serialized_size_ke
   const void * untyped_ros_message)
 {
   return get_serialized_size_key_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
-      untyped_ros_message, 0);
+    untyped_ros_message, 0);
 }
 
 static

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -45,6 +45,13 @@ for member in message.structure.members:
             _seen_nested_type_keys.add(key)
             nested_type_keys.append(key)
 
+has_buffer_field_checks = ['true' if has_direct_buffer_fields else 'false']
+has_buffer_field_checks.extend(
+    'has_buffer_fields_%s()' % '__'.join(nested_key)
+    for nested_key in nested_type_keys
+)
+has_buffer_fields_expression = ' ||\n    '.join(has_buffer_field_checks)
+
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
@@ -1156,10 +1163,7 @@ ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
 bool has_buffer_fields_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))()
 {
   return
-    @('true' if has_direct_buffer_fields else 'false')@[for nested_key in nested_type_keys]@
-
-    || has_buffer_fields_@('__'.join(nested_key))()@[end for]@
-  ;
+    @(has_buffer_fields_expression);
 }
 @# // Collect the callback functions and provide a function to get the type support struct.
 

--- a/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_fastrtps_c/resource/msg__type_support_c.cpp.em
@@ -22,13 +22,28 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import UnboundedSequence
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 
-# Detect if message has Buffer fields (only uint8[] UnboundedSequence becomes Buffer<T>)
-has_buffer_fields = False
+# Detect direct Buffer fields (only uint8[] UnboundedSequence becomes Buffer<T>).
+has_direct_buffer_fields = False
 for member in message.structure.members:
     if isinstance(member.type, UnboundedSequence):
         if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8':
-            has_buffer_fields = True
+            has_direct_buffer_fields = True
             break
+
+# Collect nested message types so the generated C helper can compose
+# has_buffer_fields transitively without needing foreign IDL structures at
+# template expansion time.
+nested_type_keys = []
+_seen_nested_type_keys = set()
+for member in message.structure.members:
+    type_ = member.type
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
+    if isinstance(type_, NamespacedType):
+        key = (*type_.namespaces, type_.name)
+        if key not in _seen_nested_type_keys:
+            _seen_nested_type_keys.add(key)
+            nested_type_keys.append(key)
 
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -50,7 +65,7 @@ header_files = [
     include_base + '__functions.h',
     'fastcdr/Cdr.h',
 ]
-if has_buffer_fields:
+if has_direct_buffer_fields:
     header_files.append('rosidl_typesupport_fastrtps_cpp/buffer_serialization.hpp')
 }@
 @[for header_file in header_files]@
@@ -206,6 +221,29 @@ ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
 @[  end if]@
 const rosidl_message_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, @(', '.join(key)))();
+
+@[  if key[0] != package_name]@
+ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
+@[  end if]@
+bool cdr_serialize_with_endpoint_@('__'.join(key))(
+  const @('__'.join(key)) * ros_message,
+  eprosima::fastcdr::Cdr & cdr,
+  const rmw_topic_endpoint_info_t & endpoint_info,
+  const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context);
+
+@[  if key[0] != package_name]@
+ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
+@[  end if]@
+bool cdr_deserialize_with_endpoint_@('__'.join(key))(
+  eprosima::fastcdr::Cdr & cdr,
+  @('__'.join(key)) * ros_message,
+  const rmw_topic_endpoint_info_t & endpoint_info,
+  const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context);
+
+@[  if key[0] != package_name]@
+ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_@(package_name)
+@[  end if]@
+bool has_buffer_fields_@('__'.join(key))();
 @[end for]@
 
 @# // Make callback functions specific to this message type.
@@ -238,6 +276,19 @@ def generate_member_for_cdr_serialize(member, suffix):
   type_ = member.type
   if isinstance(type_, AbstractNestedType):
     type_ = type_.value_type
+
+  if (
+    suffix == '_with_endpoint' and
+    isinstance(member.type, UnboundedSequence) and
+    isinstance(member.type.value_type, BasicType) and
+    member.type.value_type.typename == 'uint8'
+  ):
+    strlist.append('  rosidl_typesupport_fastrtps_cpp::serialize_buffer_or_c_sequence_with_endpoint(')
+    strlist.append('    cdr, ros_message->%s, endpoint_info, serialization_context);' % (member.name))
+    strlist.append('}')
+    return strlist
+
+  nested_extra_args = ', endpoint_info, serialization_context' if suffix == '_with_endpoint' else ''
 
   if (
     suffix == '' and
@@ -310,7 +361,8 @@ def generate_member_for_cdr_serialize(member, suffix):
       strlist.append('  }')
     elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar':
       strlist.append('  for (size_t i = 0; i < size; ++i) {')
-      strlist.append('    cdr_serialize%s_%s(' % (suffix, ('__'.join(member.type.value_type.namespaced_name()))))
+      helper_suffix = '' if suffix == '_with_endpoint' else suffix
+      strlist.append('    cdr_serialize%s_%s(' % (helper_suffix, ('__'.join(member.type.value_type.namespaced_name()))))
       strlist.append('      static_cast<wchar_t *>(&array_ptr[i]), cdr);')
       strlist.append('  }')
     elif isinstance(member.type.value_type, BasicType):
@@ -318,7 +370,7 @@ def generate_member_for_cdr_serialize(member, suffix):
     else :
       strlist.append('  for (size_t i = 0; i < size; ++i) {')
       strlist.append('    cdr_serialize%s_%s(' % (suffix, ('__'.join(member.type.value_type.namespaced_name()))))
-      strlist.append('      &array_ptr[i], cdr);')
+      strlist.append('      &array_ptr[i], cdr%s);' % nested_extra_args)
       strlist.append('  }')
   elif isinstance(member.type, AbstractString):
     strlist.append('  const rosidl_runtime_c__String * str = &ros_message->%s;' % (member.name))
@@ -341,7 +393,7 @@ def generate_member_for_cdr_serialize(member, suffix):
     strlist.append('  cdr << ros_message->%s;' % (member.name))
   else:
     strlist.append('  cdr_serialize%s_%s(' % (suffix, ('__'.join(member.type.namespaced_name()))))
-    strlist.append('    &ros_message->%s, cdr);' % (member.name))
+    strlist.append('    &ros_message->%s, cdr%s);' % (member.name, nested_extra_args))
   strlist.append('}')
 
   return strlist
@@ -349,7 +401,7 @@ def generate_member_for_cdr_serialize(member, suffix):
 
 # Generates deserialization code for a single member as a list of strings.
 # Used by both the regular and _with_endpoint deserializers.
-def generate_member_for_cdr_deserialize(member):
+def generate_member_for_cdr_deserialize(member, suffix=''):
   from rosidl_parser.definition import AbstractGenericString
   from rosidl_parser.definition import AbstractNestedType
   from rosidl_parser.definition import AbstractSequence
@@ -367,6 +419,23 @@ def generate_member_for_cdr_deserialize(member):
   type_ = member.type
   if isinstance(type_, AbstractNestedType):
     type_ = type_.value_type
+
+  if (
+    suffix == '_with_endpoint' and
+    isinstance(member.type, UnboundedSequence) and
+    isinstance(member.type.value_type, BasicType) and
+    member.type.value_type.typename == 'uint8'
+  ):
+    strlist.append('  if (!rosidl_typesupport_fastrtps_cpp::deserialize_buffer_or_c_sequence_with_endpoint(')
+    strlist.append('      cdr, ros_message->%s, endpoint_info, serialization_context))' % (member.name))
+    strlist.append('  {')
+    strlist.append('    fprintf(stderr, "Failed to deserialize buffer field \'%s\'\\n");' % (member.name))
+    strlist.append('    return false;')
+    strlist.append('  }')
+    strlist.append('}')
+    return strlist
+
+  nested_extra_args = ', endpoint_info, serialization_context' if suffix == '_with_endpoint' else ''
 
   if (
     isinstance(member.type, UnboundedSequence) and
@@ -483,7 +552,7 @@ def generate_member_for_cdr_deserialize(member):
       strlist.append('  cdr.deserialize_array(array_ptr, size);')
     else:
       strlist.append('  for (size_t i = 0; i < size; ++i) {')
-      strlist.append('    cdr_deserialize_%s(cdr, &array_ptr[i]);' % '__'.join(member.type.value_type.namespaced_name()))
+      strlist.append('    cdr_deserialize%s_%s(cdr, &array_ptr[i]%s);' % (suffix, '__'.join(member.type.value_type.namespaced_name()), nested_extra_args))
       strlist.append('  }')
 
   elif isinstance(member.type, AbstractString):
@@ -520,7 +589,7 @@ def generate_member_for_cdr_deserialize(member):
   elif isinstance(member.type, BasicType):
     strlist.append('  cdr >> ros_message->%s;' % member.name)
   else:
-    strlist.append('  cdr_deserialize_%s(cdr, &ros_message->%s);' % ('__'.join(member.type.namespaced_name()), member.name))
+    strlist.append('  cdr_deserialize%s_%s(cdr, &ros_message->%s%s);' % (suffix, '__'.join(member.type.namespaced_name()), member.name, nested_extra_args))
 
   strlist.append('}')
   return strlist
@@ -1009,10 +1078,48 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
 }
 
 @
-@[if has_buffer_fields]@
-// Endpoint-aware serialization for C messages with Buffer fields.
-// Uses the same per-field serialization as the regular path, but for uint8[] fields
-// checks the is_rosidl_buffer flag to detect rosidl::Buffer<uint8_t>*.
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
+bool cdr_serialize_with_endpoint_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
+  const @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message,
+  eprosima::fastcdr::Cdr & cdr,
+  const rmw_topic_endpoint_info_t & endpoint_info,
+  const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context)
+{
+  (void)ros_message;
+  (void)endpoint_info;
+  (void)serialization_context;
+@[for member in message.structure.members]@
+@[  for line in generate_member_for_cdr_serialize(member, '_with_endpoint')]@
+  @(line)
+@[  end for]@
+
+@[end for]@
+  return true;
+}
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
+bool cdr_deserialize_with_endpoint_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
+  eprosima::fastcdr::Cdr & cdr,
+  @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message,
+  const rmw_topic_endpoint_info_t & endpoint_info,
+  const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context)
+{
+  (void)ros_message;
+  (void)endpoint_info;
+  (void)serialization_context;
+@[for member in message.structure.members]@
+@[  for line in generate_member_for_cdr_deserialize(member, '_with_endpoint')]@
+@[    if line]@
+  @(line)
+@[    else]@
+
+@[    end if]@
+@[  end for]@
+
+@[end for]@
+  return true;
+}  // NOLINT(readability/fn_size)
+
 static bool _@(message.structure.namespaced_type.name)__cdr_serialize_with_endpoint(
   const void * untyped_ros_message,
   eprosima::fastcdr::Cdr & cdr,
@@ -1025,28 +1132,10 @@ static bool _@(message.structure.namespaced_type.name)__cdr_serialize_with_endpo
   }
   const @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message =
     static_cast<const @('__'.join(message.structure.namespaced_type.namespaced_name())) *>(untyped_ros_message);
-  (void)endpoint_info;
-@[  for member in message.structure.members]@
-@[    if isinstance(member.type, UnboundedSequence) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8']@
-  // Field name: @(member.name) (buffer-aware)
-  {
-    rosidl_typesupport_fastrtps_cpp::serialize_buffer_or_c_sequence_with_endpoint(
-      cdr, ros_message->@(member.name), endpoint_info, serialization_context);
-  }
-@[    else]@
-  // Field name: @(member.name)
-@[    for line in generate_member_for_cdr_serialize(member, '')]@
-  @(line)
-@[    end for]@
-@[    end if]@
-
-@[  end for]@
-  return true;
+  return cdr_serialize_with_endpoint_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
+    ros_message, cdr, endpoint_info, serialization_context);
 }
 
-// Endpoint-aware deserialization for C messages with Buffer fields.
-// For vendor-backed buffer data, creates a heap-allocated rosidl::Buffer<uint8_t>
-// and sets is_rosidl_buffer on the C sequence struct.
 static bool _@(message.structure.namespaced_type.name)__cdr_deserialize_with_endpoint(
   eprosima::fastcdr::Cdr & cdr,
   void * untyped_ros_message,
@@ -1059,33 +1148,19 @@ static bool _@(message.structure.namespaced_type.name)__cdr_deserialize_with_end
   }
   @('__'.join(message.structure.namespaced_type.namespaced_name())) * ros_message =
     static_cast<@('__'.join(message.structure.namespaced_type.namespaced_name())) *>(untyped_ros_message);
-  (void)endpoint_info;
-@[  for member in message.structure.members]@
-@[    if isinstance(member.type, UnboundedSequence) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8']@
-  // Field name: @(member.name) (buffer-aware)
-  {
-    if (!rosidl_typesupport_fastrtps_cpp::deserialize_buffer_or_c_sequence_with_endpoint(
-        cdr, ros_message->@(member.name), endpoint_info, serialization_context))
-    {
-      fprintf(stderr, "Failed to deserialize buffer field '@(member.name)'\n");
-      return false;
-    }
-  }
-@[    else]@
-  // Field name: @(member.name)
-@[    for line in generate_member_for_cdr_deserialize(member)]@
-@[      if line]@
-  @(line)
-@[      else]@
+  return cdr_deserialize_with_endpoint_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(
+    cdr, ros_message, endpoint_info, serialization_context);
+}
 
-@[      end if]@
-@[    end for]@
-@[    end if]@
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_@(package_name)
+bool has_buffer_fields_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))()
+{
+  return
+    @('true' if has_direct_buffer_fields else 'false')@[for nested_key in nested_type_keys]@
 
-@[  end for]@
-  return true;
-}  // NOLINT(readability/fn_size)
-@[end if]@
+    || has_buffer_fields_@('__'.join(nested_key))()@[end for]@
+  ;
+}
 @# // Collect the callback functions and provide a function to get the type support struct.
 
 static message_type_support_callbacks_t __callbacks_@(message.structure.namespaced_type.name) = {
@@ -1100,14 +1175,9 @@ static message_type_support_callbacks_t __callbacks_@(message.structure.namespac
 @[  else]@
   nullptr,
 @[  end if]@
-  @('true' if has_buffer_fields else 'false'),
-@[  if has_buffer_fields]@
+  has_buffer_fields_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(),
   _@(message.structure.namespaced_type.name)__cdr_serialize_with_endpoint,
   _@(message.structure.namespaced_type.name)__cdr_deserialize_with_endpoint
-@[  else]@
-  nullptr,
-  nullptr
-@[  end if]@
 };
 
 static rosidl_message_type_support_t _@(message.structure.namespaced_type.name)__type_support = {

--- a/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_cpp/cmake/rosidl_typesupport_fastrtps_cpp_generate_interfaces.cmake
@@ -182,6 +182,10 @@ target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBL
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_cpp)
 
+# Generated C++ typesupport delegates transitive Buffer-field detection to the generated C helper
+target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PRIVATE
+  ${rosidl_generate_interfaces_TARGET}__rosidl_typesupport_fastrtps_c)
+
 # Make top level generation target depend on this library
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__rosidl_typesupport_fastrtps_cpp.hpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__rosidl_typesupport_fastrtps_cpp.hpp.em
@@ -107,6 +107,10 @@ max_serialized_size_key_@(message.structure.namespaced_type.name)(
   bool & is_plain,
   size_t current_alignment);
 
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_@(package_name)
+has_buffer_fields_@(message.structure.namespaced_type.name)();
+
 }  // namespace typesupport_fastrtps_cpp
 @[  for ns in reversed(message.structure.namespaced_type.namespaces)]@
 

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -13,9 +13,15 @@ from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import UnboundedSequence
+from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
+
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_base = '/'.join(include_parts)
 
 header_files = [
     'cstddef',
+    'cstdio',
     'limits',
     'stdexcept',
     'string',
@@ -24,19 +30,20 @@ header_files = [
     'rosidl_typesupport_fastrtps_cpp/message_type_support.h',
     'rosidl_typesupport_fastrtps_cpp/message_type_support_decl.hpp',
     'rosidl_typesupport_fastrtps_cpp/serialization_helpers.hpp',
+    include_base + '__rosidl_typesupport_fastrtps_c.h',
     'fastcdr/Cdr.h',
 ]
 
-# Detect if message has Buffer fields (only uint8[] UnboundedSequence becomes Buffer<T>)
-has_buffer_fields = False
+# Detect direct Buffer fields (only uint8[] UnboundedSequence becomes Buffer<T>).
+has_direct_buffer_fields = False
 for member in message.structure.members:
     if isinstance(member.type, UnboundedSequence):
         # Only uint8[] arrays use Buffer
         if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8':
-            has_buffer_fields = True
+            has_direct_buffer_fields = True
             break
 
-if has_buffer_fields:
+if has_direct_buffer_fields:
     header_files.append('rosidl_typesupport_fastrtps_cpp/buffer_serialization.hpp')
 }@
 @[for header_file in header_files]@
@@ -97,6 +104,16 @@ max_serialized_size_key_@(type_.name)(
   bool & full_bounded,
   bool & is_plain,
   size_t current_alignment);
+bool cdr_serialize_with_endpoint(
+  const @('::'.join(type_.namespaced_name())) &,
+  eprosima::fastcdr::Cdr &,
+  const rmw_topic_endpoint_info_t &,
+  const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext &);
+bool cdr_deserialize_with_endpoint(
+  eprosima::fastcdr::Cdr &,
+  @('::'.join(type_.namespaced_name())) &,
+  const rmw_topic_endpoint_info_t &,
+  const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext &);
 }  // namespace typesupport_fastrtps_cpp
 @[      for ns in reversed(type_.namespaces)]@
 }  // namespace @(ns)
@@ -163,7 +180,8 @@ def generate_member_for_cdr_serialize(member, suffix, endpoint_param=''):
         strlist.append('}')
         return strlist
   
-  nested_msg_suffix = '' if suffix == '_with_endpoint' else suffix
+  nested_msg_suffix = suffix
+  nested_extra_args = ', %s, serialization_context' % endpoint_param if suffix == '_with_endpoint' else ''
   if isinstance(member.type, AbstractNestedType):
     strlist.append('{')
     if isinstance(member.type, Array):
@@ -174,7 +192,7 @@ def generate_member_for_cdr_serialize(member, suffix, endpoint_param=''):
         if isinstance(member.type.value_type, NamespacedType):
           strlist.append('    %s::typesupport_fastrtps_cpp::cdr_serialize%s(' % (('::'.join(member.type.value_type.namespaces)), nested_msg_suffix))
           strlist.append('      ros_message.%s[i],' % (member.name))
-          strlist.append('      cdr);')
+          strlist.append('      cdr%s);' % nested_extra_args)
         else:
           strlist.append('    rosidl_typesupport_fastrtps_cpp::cdr_serialize(cdr, ros_message.%s[i]);' % (member.name))
         strlist.append('  }')
@@ -206,7 +224,7 @@ def generate_member_for_cdr_serialize(member, suffix, endpoint_param=''):
           else:
             strlist.append('    %s::typesupport_fastrtps_cpp::cdr_serialize%s(' % (('::'.join(member.type.value_type.namespaces)), nested_msg_suffix))
             strlist.append('      ros_message.%s[i],' % (member.name))
-            strlist.append('      cdr);')
+            strlist.append('      cdr%s);' % nested_extra_args)
           strlist.append('  }')
     strlist.append('}')
   elif isinstance(member.type, BasicType) and member.type.typename == 'boolean':
@@ -222,7 +240,7 @@ def generate_member_for_cdr_serialize(member, suffix, endpoint_param=''):
   else:
     strlist.append('%s::typesupport_fastrtps_cpp::cdr_serialize%s(' % (('::'.join(member.type.namespaces)), nested_msg_suffix))
     strlist.append('  ros_message.%s,' % (member.name))
-    strlist.append('  cdr);')
+    strlist.append('  cdr%s);' % nested_extra_args)
   return strlist
 }@
 
@@ -349,8 +367,8 @@ cdr_deserialize(
   return true;
 }  // NOLINT(readability/fn_size)
 
-@[if has_buffer_fields]@
-// Endpoint-aware serialization for Buffer message types
+// Endpoint-aware serialization. Always emitted so parent messages can recurse
+// through non-Buffer intermediate message types.
 bool
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_@(package_name)
 cdr_serialize_with_endpoint(
@@ -359,23 +377,27 @@ cdr_serialize_with_endpoint(
   const rmw_topic_endpoint_info_t & endpoint_info,
   const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context)
 {
+  (void)ros_message;
+  (void)endpoint_info;
+  (void)serialization_context;
   try {
-    // Serialize all fields, using endpoint-aware serialization for Buffer fields
 @[for member in message.structure.members]@
 @[  for line in generate_member_for_cdr_serialize(member, '_with_endpoint', 'endpoint_info')]@
     @(line)
 @[  end for]@
 @[end for]@
   } catch (const std::exception & e) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "@(package_name).typesupport_fastrtps_cpp",
-      "cdr_serialize_with_endpoint failed: %s", e.what());
+    fprintf(
+      stderr,
+      "[@(package_name).typesupport_fastrtps_cpp] cdr_serialize_with_endpoint failed: %s\n",
+      e.what());
     return false;
   }
   return true;
 }
 
-// Endpoint-aware deserialization for Buffer message types
+// Endpoint-aware deserialization. Always emitted so parent messages can recurse
+// through non-Buffer intermediate message types.
 bool
 ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_@(package_name)
 cdr_deserialize_with_endpoint(
@@ -384,7 +406,9 @@ cdr_deserialize_with_endpoint(
   const rmw_topic_endpoint_info_t & endpoint_info,
   const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context)
 {
-  // Deserialize all fields, using endpoint-aware deserialization for Buffer fields (UnboundedSequence)
+  (void)ros_message;
+  (void)endpoint_info;
+  (void)serialization_context;
 @[for member in message.structure.members]@
   // Member: @(member.name)
 @[  if isinstance(member.type, UnboundedSequence) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8']@
@@ -392,9 +416,10 @@ cdr_deserialize_with_endpoint(
     if (!rosidl_typesupport_fastrtps_cpp::deserialize_buffer_with_endpoint(
         cdr, ros_message.@(member.name), endpoint_info, serialization_context))
     {
-      RCUTILS_LOG_ERROR_NAMED(
-        "@(package_name).typesupport_fastrtps_cpp",
-        "cdr_deserialize_with_endpoint: failed to deserialize '@(member.name)'");
+      fprintf(
+        stderr,
+        "[@(package_name).typesupport_fastrtps_cpp] "
+        "cdr_deserialize_with_endpoint: failed to deserialize '@(member.name)'\n");
       return false;
     }
   }
@@ -406,9 +431,11 @@ cdr_deserialize_with_endpoint(
 @[      else]@
     for (size_t i = 0; i < @(member.type.size); i++) {
 @[        if isinstance(member.type.value_type, NamespacedType)]@
-      @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
+      @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize_with_endpoint(
         cdr,
-        ros_message.@(member.name)[i]);
+        ros_message.@(member.name)[i],
+        endpoint_info,
+        serialization_context);
 @[        else]@
       bool succeeded = rosidl_typesupport_fastrtps_cpp::cdr_deserialize(cdr, ros_message.@(member.name)[i]);
       if (!succeeded) {
@@ -447,16 +474,28 @@ cdr_deserialize_with_endpoint(
     }
 @[        else]@
     for (size_t i = 0; i < size; i++) {
-@[          if isinstance(member.type.value_type, NamespacedType)]@
-      @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
-        cdr,
-        ros_message.@(member.name)[i]);
-@[          else]@
+@[          if isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'boolean']@
+      uint8_t tmp;
+      cdr >> tmp;
+      ros_message.@(member.name)[i] = tmp ? true : false;
+@[          elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'wchar']@
+      wchar_t tmp;
+      cdr >> tmp;
+      ros_message.@(member.name)[i] = static_cast<char16_t>(tmp);
+@[          elif isinstance(member.type.value_type, AbstractWString)]@
       bool succeeded = rosidl_typesupport_fastrtps_cpp::cdr_deserialize(cdr, ros_message.@(member.name)[i]);
       if (!succeeded) {
         fprintf(stderr, "failed to deserialize u16string\n");
         return false;
       }
+@[          elif not isinstance(member.type.value_type, NamespacedType)]@
+      cdr >> ros_message.@(member.name)[i];
+@[          else]@
+      @('::'.join(member.type.value_type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize_with_endpoint(
+        cdr,
+        ros_message.@(member.name)[i],
+        endpoint_info,
+        serialization_context);
 @[          end if]@
     }
 @[        end if]@
@@ -482,15 +521,16 @@ cdr_deserialize_with_endpoint(
 @[  elif not isinstance(member.type, NamespacedType)]@
   cdr >> ros_message.@(member.name);
 @[  else]@
-  @('::'.join(member.type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize(
+  @('::'.join(member.type.namespaces))::typesupport_fastrtps_cpp::cdr_deserialize_with_endpoint(
     cdr,
-    ros_message.@(member.name));
+    ros_message.@(member.name),
+    endpoint_info,
+    serialization_context);
 @[  end if]@
 
 @[end for]@
   return true;
 }
-@[end if]@
 @{
 
 # Generates the definition for the get_serialized_size family of methods given a structure member
@@ -919,7 +959,6 @@ static size_t _@(message.structure.namespaced_type.name)__max_serialized_size(ch
   return ret_val;
 }
 
-@[if has_buffer_fields]@
 // Endpoint-aware serialization wrapper
 static bool _@(message.structure.namespaced_type.name)__cdr_serialize_with_endpoint(
   const void * untyped_ros_message,
@@ -945,7 +984,13 @@ static bool _@(message.structure.namespaced_type.name)__cdr_deserialize_with_end
     untyped_ros_message);
   return cdr_deserialize_with_endpoint(cdr, *typed_message, endpoint_info, serialization_context);
 }
-@[end if]@
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_@(package_name)
+has_buffer_fields_@(message.structure.namespaced_type.name)()
+{
+  return has_buffer_fields_@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))();
+}
 
 static message_type_support_callbacks_t _@(message.structure.namespaced_type.name)__callbacks = {
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",
@@ -959,14 +1004,9 @@ static message_type_support_callbacks_t _@(message.structure.namespaced_type.nam
 @[  else]@
   nullptr,
 @[  end if]@
-  @('true' if has_buffer_fields else 'false'),
-@[  if has_buffer_fields]@
+  has_buffer_fields_@(message.structure.namespaced_type.name)(),
   _@(message.structure.namespaced_type.name)__cdr_serialize_with_endpoint,
   _@(message.structure.namespaced_type.name)__cdr_deserialize_with_endpoint
-@[  else]@
-  nullptr,
-  nullptr
-@[  end if]@
 };
 
 static rosidl_message_type_support_t _@(message.structure.namespaced_type.name)__handle = {

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -529,7 +529,7 @@ cdr_deserialize_with_endpoint(
 
 @[end for]@
   return true;
-}
+}  // NOLINT(readability/fn_size)
 @{
 
 # Generates the definition for the get_serialized_size family of methods given a structure member

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -25,6 +25,7 @@ header_files = [
     'limits',
     'stdexcept',
     'string',
+    'rcutils/logging_macros.h',
     'rosidl_typesupport_cpp/message_type_support.hpp',
     'rosidl_typesupport_fastrtps_cpp/identifier.hpp',
     'rosidl_typesupport_fastrtps_cpp/message_type_support.h',
@@ -387,10 +388,9 @@ cdr_serialize_with_endpoint(
 @[  end for]@
 @[end for]@
   } catch (const std::exception & e) {
-    fprintf(
-      stderr,
-      "[@(package_name).typesupport_fastrtps_cpp] cdr_serialize_with_endpoint failed: %s\n",
-      e.what());
+    RCUTILS_LOG_ERROR_NAMED(
+      "@(package_name).typesupport_fastrtps_cpp",
+      "cdr_serialize_with_endpoint failed: %s", e.what());
     return false;
   }
   return true;
@@ -416,10 +416,9 @@ cdr_deserialize_with_endpoint(
     if (!rosidl_typesupport_fastrtps_cpp::deserialize_buffer_with_endpoint(
         cdr, ros_message.@(member.name), endpoint_info, serialization_context))
     {
-      fprintf(
-        stderr,
-        "[@(package_name).typesupport_fastrtps_cpp] "
-        "cdr_deserialize_with_endpoint: failed to deserialize '@(member.name)'\n");
+      RCUTILS_LOG_ERROR_NAMED(
+        "@(package_name).typesupport_fastrtps_cpp",
+        "cdr_deserialize_with_endpoint: failed to deserialize '@(member.name)'");
       return false;
     }
   }

--- a/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_fastrtps_cpp/resource/msg__type_support.cpp.em
@@ -558,7 +558,7 @@ def generate_member_for_get_serialized_size(member, suffix):
       # Call the Buffer-specific serialization size function
       strlist.append('current_alignment +=')
       strlist.append('  rosidl_typesupport_fastrtps_cpp::get_buffer_serialized_size(')
-      strlist.append('    ros_message.%s, current_alignment);' % (member.name))
+      strlist.append('  ros_message.%s, current_alignment);' % (member.name))
       return strlist
     
     strlist.append('{')


### PR DESCRIPTION
## Description

Fix nested `uint8[]` fields backed by `rosidl::Buffer` not being detected by Fast RTPS endpoint-aware serialization.

Previously, Fast RTPS typesupport only marked a message as having Buffer fields when the current message directly contained a `uint8[]`. If the Buffer field was inside a nested message, the top-level message was treated as not buffer-aware, so RMW used the normal serialization path that forces conversion to CPU for the buffer fields.

This change generates transitive `has_buffer_fields` helpers. The C typesupport helper returns true when a message has a direct `uint8[]` or any nested message reports Buffer fields. C++ typesupport delegates to the C helper. With this flag, RMW can correctly select endpoint-aware serialization for messages whose Buffer fields are nested. No change is needed for the RMW side as the flag used by RMW (`rmw_fastrtps_cpp`) stays the same.

### Is this user-facing behavior change?

Yes. Messages with nested `uint8[]` / `rosidl::Buffer` fields now preserve endpoint/backend-aware serialization behavior instead of falling back to the normal serialization path that forces to pass buffer fields with CPU-based data. This only affects users that explicitly opt-in to use the buffer backend feature.

### Did you use Generative AI?

Yes, GPT-5.5 was used to assist with developing changes contained in this PR.
