### PR TITLE
Clean up logs in buffer serialization functions

### DIFF
--- a/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/buffer_serialization.hpp
+++ b/rosidl_typesupport_fastrtps_cpp/include/rosidl_typesupport_fastrtps_cpp/buffer_serialization.hpp
@@ -137,11 +137,10 @@ inline void serialize_buffer_with_endpoint(
 {
   const std::string backend_type = buffer.get_backend_type();
 
-  RCUTILS_LOG_INFO_NAMED("serialize_buffer_with_endpoint",
+  RCUTILS_LOG_DEBUG_NAMED("serialize_buffer_with_endpoint",
     ("Serializing buffer (backend: " + backend_type + ")").c_str());
 
   if (backend_type == "cpu") {
-    RCUTILS_LOG_INFO_NAMED("serialize_buffer_with_endpoint", "Serializing buffer as std::vector");
     const std::vector<T, Allocator> & vec = buffer;
     cdr << vec;
     return;
@@ -159,7 +158,7 @@ inline void serialize_buffer_with_endpoint(
   {
     RCUTILS_LOG_WARN_NAMED(
       "serialize_buffer_with_endpoint",
-      "Backend '%s' not available (shutdown?), falling back to CPU wire format",
+      "Backend '%s' not available, falling back to CPU wire format",
       backend_type.c_str());
     std::vector<T, Allocator> vec = buffer.to_vector();
     cdr << vec;
@@ -170,7 +169,7 @@ inline void serialize_buffer_with_endpoint(
 
   // nullptr means the backend cannot handle this endpoint — fall back to CPU wire format.
   if (!descriptor) {
-    RCUTILS_LOG_INFO_NAMED(
+    RCUTILS_LOG_DEBUG_NAMED(
       "serialize_buffer_with_endpoint", "Backend returned null descriptor, falling back to CPU");
     std::vector<T, Allocator> vec = buffer.to_vector();
     cdr << vec;
@@ -181,9 +180,6 @@ inline void serialize_buffer_with_endpoint(
   cdr << static_cast<uint32_t>(kBufferDescriptorMarker1);
   cdr << static_cast<uint32_t>(kBufferDescriptorMarker2);
   cdr << backend_type;
-
-  RCUTILS_LOG_INFO_NAMED("serialize_buffer_with_endpoint",
-    ("Serializing descriptor for backend: " + backend_type).c_str());
 
   ser_it->second.serialize(cdr, descriptor, endpoint_info, serialization_context);
 }
@@ -198,8 +194,6 @@ inline bool deserialize_buffer_with_endpoint(
   const rmw_topic_endpoint_info_t & endpoint_info,
   const BufferSerializationContext & serialization_context)
 {
-  RCUTILS_LOG_INFO_NAMED("deserialize_buffer_with_endpoint", "Starting buffer deserialization");
-
   // Peek to disambiguate CPU vector bytes vs descriptor payload.
   // Only read the second word when the first matches — an empty vector (uint32 length = 0)
   // may leave fewer than 8 bytes in the CDR buffer, so reading two words unconditionally
@@ -215,8 +209,6 @@ inline bool deserialize_buffer_with_endpoint(
   }
 
   if (!is_descriptor_path) {
-    RCUTILS_LOG_INFO_NAMED(
-      "deserialize_buffer_with_endpoint", "Legacy vector path: deserializing std::vector");
     cdr.set_state(original_state);
     std::vector<T, Allocator> & storage = buffer;
     cdr >> storage;
@@ -225,7 +217,7 @@ inline bool deserialize_buffer_with_endpoint(
 
   std::string backend_type;
   cdr >> backend_type;
-  RCUTILS_LOG_INFO_NAMED("deserialize_buffer_with_endpoint",
+  RCUTILS_LOG_DEBUG_NAMED("deserialize_buffer_with_endpoint",
     (backend_type + " backend: deserializing descriptor").c_str());
 
   auto ops_it = serialization_context.descriptor_ops.find(backend_type);
@@ -241,11 +233,9 @@ inline bool deserialize_buffer_with_endpoint(
   }
 
   // Deserialize descriptor
-  RCUTILS_LOG_INFO_NAMED("deserialize_buffer_with_endpoint", "Deserializing descriptor");
   auto descriptor = ser_it->second.deserialize(cdr, endpoint_info, serialization_context);
 
   // Create buffer implementation with endpoint awareness
-  RCUTILS_LOG_INFO_NAMED("deserialize_buffer_with_endpoint", "Creating buffer from descriptor");
   auto impl_erased = ops_it->second.from_descriptor_with_endpoint(descriptor.get(), endpoint_info);
 
   std::unique_ptr<rosidl::BufferImplBase<T>> typed_impl(
@@ -366,7 +356,7 @@ inline Cdr & operator<<(Cdr & cdr, const rosidl::Buffer<T, Allocator> & buffer)
     const std::vector<T, Allocator> & vec = buffer;
     cdr << vec;
   } else {
-    RCUTILS_LOG_INFO_NAMED("Serialize Buffer<T>",
+    RCUTILS_LOG_DEBUG_NAMED("Serialize Buffer<T>",
       ("Force-converting to CPU buffer for serialization (backend: " + backend_type + ")").c_str());
     std::vector<T, Allocator> vec = buffer.to_vector();
     cdr << vec;


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Remove redundant logs and change the remaining logs from INFO to DEBUG level in buffer serialization functions.


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Users now only see buffer serialization logs in DEBUG log level.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

NA