### PR TITLE
Enforce c++ language for cppcheck_rosidl_typesupport_fastrtps_c

### DIFF
--- a/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_fastrtps_c/cmake/rosidl_typesupport_fastrtps_c_generate_interfaces.cmake
@@ -210,6 +210,7 @@ if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
   find_package(ament_cmake_cppcheck REQUIRED)
   ament_cppcheck(
     TESTNAME "cppcheck_rosidl_typesupport_fastrtps_c"
+    LANGUAGE c++
     ${_generated_files})
 
   find_package(ament_cmake_cpplint REQUIRED)


### PR DESCRIPTION
## Description

Addresses #157 

This fixes the cppcheck issue, but does not deal with the underlying issue of using C++ in C (?) headers.
If the latter is intended, then this PR is a proper fix.

### Is this user-facing behavior change?

I would lean towards no..

### Did you use Generative AI?

No

### Additional Information

This should get backported to lyrical as well.